### PR TITLE
Ensure that .post/.posts fits on screen when viewport width is [1500px, ~1520px]

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -949,7 +949,7 @@ a.blockButton {
 
   .mainContainer .mainWrapper {
     .post, .posts {
-      width: 1060px;
+      width: 1035px;
     }
   }
 }


### PR DESCRIPTION
Before:
![screen shot 2015-06-11 at 11 01 04](https://cloud.githubusercontent.com/assets/44190/8114426/5f1f3bbc-1029-11e5-82a9-e4128cbefd85.png)

After:
![screen shot 2015-06-11 at 11 01 07](https://cloud.githubusercontent.com/assets/44190/8114430/65044978-1029-11e5-8650-715d9a83d75b.png)

Thanks and congrats on the launch!