### PR TITLE
Handle spaces in repository path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ infer/models/out/
 /infer/src/clang/clang_ast_t.mli
 
 /infer/annotations/annotations.jar
+
+/.facebook-clang-plugin-dir

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,9 @@ To compile support for both Java and C/Objective-C, do this instead.
 
 ```bash
 cd infer
-./update-fcp.sh && ../facebook-clang-plugin/clang/setup.sh && ./compile-fcp.sh # go have a coffee :)
+./update-fcp.sh
+$(cat .facebook-clang-plugin-dir)/facebook-clang-plugin/clang/setup.sh  # go have a coffee :)
+./compile-fcp.sh
 make -C infer
 export PATH=`pwd`/infer/bin:$PATH
 ```
@@ -154,14 +156,14 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install gcc-4.8 g++-4.8
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
-``` 
+```
 
 Then continue with:
 
 ```bash
 cd infer
 ./update-fcp.sh
-../facebook-clang-plugin/clang/setup.sh  # go have a coffee :)
+$(cat .facebook-clang-plugin-dir)/facebook-clang-plugin/clang/setup.sh  # go have a coffee :)
 ./compile-fcp.sh
 make -C infer
 export PATH=`pwd`/infer/bin:$PATH

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,6 +94,8 @@ opam init --comp=4.01.0  # (answer 'y' to the question)
 opam install sawja.1.5 atdgen.1.5.0 javalib.2.3 extlib.1.5.4
 ```
 
+> Note that opam modifies your login scripts, and those environment changes will need to be loaded into your bash session before proceeding.
+
 If you do not require support for the C/Objective-C analysis in Infer,
 and only wish to analyse Java files, continue with these
 instructions. By the way, Java 1.8 is not supported.

--- a/compile-fcp.sh
+++ b/compile-fcp.sh
@@ -8,7 +8,11 @@ set -x
 # THE INSTALLATION OF THE PLUGINS.
 
 INFER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PLUGIN_DIR="$INFER_ROOT/../facebook-clang-plugin"
+
+# Find the temp directory with the clang plugin
+PLUGIN_POINTER_FILE="$INFER_ROOT/.facebook-clang-plugin-dir"
+PLUGIN_SETUP_DIR="$( cat "$PLUGIN_POINTER_FILE" )"
+PLUGIN_DIR="$PLUGIN_SETUP_DIR/facebook-clang-plugin"
 CLANG_EXEC="$PLUGIN_DIR/clang/bin/clang"
 
 # check if clang is available

--- a/update-fcp.sh
+++ b/update-fcp.sh
@@ -7,8 +7,22 @@ set -e
 
 INFER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PLUGIN_REPO=https://github.com/facebook/facebook-clang-plugins
-PLUGIN_DIR="$INFER_ROOT/../facebook-clang-plugin"
 VERSION_FILE="$INFER_ROOT/dependencies/clang-plugin/clang-plugin-version.config"
+
+
+# Since we need to use autotools, ensure that we don't do it
+# in a path that contains a space.  The path will be cached here
+PLUGIN_POINTER_FILE="$INFER_ROOT/.facebook-clang-plugin-dir"
+if [ ! -e "$PLUGIN_POINTER_FILE" ]; then
+    mktemp -d /tmp/facebook-clang-plugin-setup.XXXXXX > "$PLUGIN_POINTER_FILE"
+fi
+
+PLUGIN_SETUP_DIR="$( cat "$PLUGIN_POINTER_FILE" )"
+if [ ! -d "$PLUGIN_SETUP_DIR" ]; then
+    mkdir -p "$PLUGIN_SETUP_DIR"
+fi
+
+PLUGIN_DIR="$PLUGIN_SETUP_DIR/facebook-clang-plugin"
 
 # check if the repo is already in place
 if [ ! -e "$PLUGIN_DIR" ]; then
@@ -18,7 +32,7 @@ fi
 
 # update revision if needed
 echo "Checking out the right version of the clang plugin..."
-pushd $PLUGIN_DIR
+pushd "$PLUGIN_DIR"
 git checkout master
 git $GIT_OPTIONS pull
 git checkout $(cat "$VERSION_FILE")


### PR DESCRIPTION
The install scripts are messy, and this causes problems.

`update-fcp.sh` downloads a separate repository (facebook-clang-plugin) into the parent directory of the infer repository.  Running the setup file in this directory can fail, because facebook-clang-plugin contains a gzipped archive of an autoconf'd `llvm`, which can't account for spaces in the prefix dir path (the `facebook-clang-plugin` repository directory, in this case).  This appears to be an autotools problem.

Rather than update the gzipped archive in the facebook-clang-plugin repository, it seems reasonable to control where that dependency is auto-downloaded to.