### PR TITLE
OS X install script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,31 +46,40 @@ dependencies. Details below.
 
 Install the OCaml dependencies:
 
-```bash
-opam init --comp=4.01.0  # (answer 'y' to the question)
-eval `opam config env`
-opam install sawja.1.5 atdgen.1.5.0 javalib.2.3a extlib.1.5.4
+If you do not require support for the C/Objective-C analysis in Infer, and only
+wish to analyse Java files, run `scripts/mac_osx_build.sh` with the following
+options. By the way, Java 1.8 is not supported.
+
+```
+./scripts/mac_osx_build.sh --java-only
+export PATH=`pwd`/infer/bin:$PATH
 ```
 
-If you do not require support for the C/Objective-C analysis in Infer,
-and only wish to analyse Java files, continue with these
-instructions. By the way, Java 1.8 is not supported.
+Once you've installed the dependencies, you can simply execute the following
+from the `infer` directory to re-build:
 
 ```bash
 cd infer
 make -C infer java
+```
+
+To install build dependencies and compile support for both Java and
+C/Objective-C, do this instead.
+
+```bash
+./scripts/mac_osx_build.sh
 export PATH=`pwd`/infer/bin:$PATH
 ```
 
-To compile support for both Java and C/Objective-C, do this instead.
+Once you've installed the dependencies, you can simply execute the following
+from the `infer` directory to re-build:
 
 ```bash
 cd infer
-./update-fcp.sh && ../facebook-clang-plugin/clang/setup.sh && ./compile-fcp.sh # go have a coffee :)
 make -C infer
-export PATH=`pwd`/infer/bin:$PATH
 ```
 
+To update the Facebook clang plugins, simply re-run `mac_osx_build.sh`.
 
 ## Linux
 

--- a/scripts/check_clang_plugin_version.sh
+++ b/scripts/check_clang_plugin_version.sh
@@ -37,7 +37,8 @@ cd $REPO_DIR
 [ ! -d ".git" ] && {
     echoerr "SKIPPING the facebook-clang-plugins version check since";
     echoerr "$REPO_DIR is NOT a Git repository";
-    exit 0;
+    echoerr "To ensure that you keep clang plugins in sync with Infer, consider \
+deleting $REPO_DIR and running this script again."
 }
 
 echoerr "Checking that the revision of facebook-clang-plugins is correct..."

--- a/scripts/mac_osx_build.sh
+++ b/scripts/mac_osx_build.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2015, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+INFER_ROOT="$SCRIPT_DIR/../"
+
+function usage() {
+  echo "Usage: $0 [options]"
+  echo
+  echo " options:"
+  echo "    --java-only   only build Java support (default: false)"
+  echo "    --no-init     do not initialize OPAM"
+  echo
+  echo " examples:"
+  echo "    $0                # build Java and C/Objective-C support"
+  echo "    $0  --java-only   # build Java support"
+  exit 1
+}
+
+JAVA_ONLY=
+NO_INIT=
+while [[ $# > 0 ]]; do
+  opt_key="$1"
+  case $opt_key in
+    -j|--java-only)
+      JAVA_ONLY=1
+      shift
+      continue
+      ;;
+    -n|--no-init)
+      NO_INIT=1
+      shift
+      continue
+      ;;
+    -h|--help)
+      usage
+  esac
+  shift
+done
+
+function brew_install() {
+  if [[ -n "$(brew list | grep $1)" ]]; then
+    echo "$1 is already installed. skipping."
+  else
+    echo "installing $1"
+    brew install --build-bottle --build-from-source $1 || brew upgrade --build-from-source $@
+  fi
+}
+
+function opam_install() {
+  if [[ -n "$(opam list | grep -e "$1\s*$2")" ]]; then
+    echo "$1 is already installed. skipping."
+  else
+    echo "installing $1"
+    opam install $1.$2 -y
+  fi
+}
+
+function main() {
+  platform=`uname`
+  if [ $platform != "Darwin" ]; then
+    echo "This setup script works only on MacOS"
+    exit 1
+  fi
+
+  type brew >/dev/null 2>&1 || {
+    echo "could not find homebrew. please install it from http://brew.sh/";
+    exit 1
+  }
+
+  brew_install opam
+  opam init --comp=4.01.0 -y
+  opam_install sawja 1.5
+  opam_install atdgen 1.5.0
+  opam_install javalib 2.3
+  opam_install extlib 1.5.4
+  if [ ! $NO_INIT ]; then
+    opam config env
+  fi
+
+  if [ $JAVA_ONLY ]; then
+    cd $INFER_ROOT
+    make -C infer java
+  else
+    $INFER_ROOT/scripts/check_clang_plugin_version.sh $INFER_ROOT/../facebook-clang-plugin
+    if [ $? -ne 0 ]; then
+      echo "facebook-clang-plugin is not up-to-date. installing..."
+      $INFER_ROOT/update-fcp.sh
+      $INFER_ROOT/../facebook-clang-plugin/clang/setup.sh
+      $INFER_ROOT/compile-fcp.sh
+    fi
+
+    cd $INFER_ROOT
+    make -C infer
+  fi
+}
+
+main


### PR DESCRIPTION
A build script for building infer on a new OS X machine.

Help text:

```shell
$ ./scripts/mac_osx_build.sh --help
Usage: ./scripts/mac_osx_build.sh [options]

 options:
    --java-only   only build Java support (default: false)

 examples:
    ./scripts/mac_osx_build.sh                # build Java and C/Objective-C support
    ./scripts/mac_osx_build.sh  --java-only   # build Java support
```

I'm not sure if this is desired / needed, but I saw people having some trouble in #26, so I figured that I would document the installation steps in a reproducible tool.