### PR TITLE
Add OPAM metadata files to permit direct installation of Infer

### DIFF
--- a/infer.install
+++ b/infer.install
@@ -1,0 +1,14 @@
+bin: [
+  "infer/bin/infer"
+  "infer/bin/inferTest"
+  "infer/bin/inferTraceBugs"
+  "infer/bin/InferJava"
+  "?infer/bin/InferClang"
+  "infer/bin/InferAnalyze"
+  "infer/bin/InferPrint"
+  "infer/bin/inferJ"
+  "infer/bin/BuckAnalyze"
+  "infer/bin/inferlib.py"
+  "infer/bin/utils.py"
+  "infer/bin/jwlib.py"
+]

--- a/opam
+++ b/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "infer"
+version: "0.1.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: "Facebook"
+homepage: "https://github.com/facebook/infer"
+bug-reports: "https://github.com/facebook/infer/issues"
+dev-repo: "https://github.com/facebook/infer.git"
+license: "BSD"
+build: [ [make "-C" "infer" "java"] ]
+install: []
+remove: []
+depends: [
+  "ocamlfind" {build}
+  "sawja" {>="1.5"}
+  "atdgen" {>="1.5"}
+  "javalib" {>="2.3"}
+  "extlib" {>="1.5.4"}
+]
+depexts: [
+  [ ["ubuntu"] ["python2.7-dev"] ]
+  [ ["debian"] ["python2.7-dev"] ]
+]


### PR DESCRIPTION
This lets `opam pin add git://github.com/facebook/infer` work
out of the box by adding enough metadata to install all the
OCaml dependencies.  It currently doesn't install the Clang
analyzer in the build rules.