### PR TITLE
updated GitHub link in nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -10,6 +10,6 @@
   href: blog/
   category: blog
 
-- title: Github
+- title: GitHub
   href: http://github.com/facebook/infer
   category: github


### PR DESCRIPTION
When I looked at some new open source projects that came out this week, I noticed the current nav item for the link to GitHub for this project showed the lowercase H. This is just a quick fix for that

If there's something else I missed, happy to make changes to this branch! :heart_eyes: 