### PR TITLE
[Java] Force javac to report in the correct language

### DIFF
--- a/infer/bin/jwlib.py
+++ b/infer/bin/jwlib.py
@@ -31,7 +31,8 @@ class CompilerCall:
         if self.args.version:
             return subprocess.call(['javac'] + self.original_arguments)
         else:
-            javac_cmd = ['javac', '-verbose', '-g', '-J-Duser.language=en'] + self.original_arguments
+            javac_cmd = ['javac', '-verbose', '-g'] + self.original_arguments
+            javac_cmd.append('-J-Duser.language=en')
 
             with tempfile.NamedTemporaryFile(
                     mode='w',

--- a/infer/bin/jwlib.py
+++ b/infer/bin/jwlib.py
@@ -31,7 +31,7 @@ class CompilerCall:
         if self.args.version:
             return subprocess.call(['javac'] + self.original_arguments)
         else:
-            javac_cmd = ['javac', '-verbose', '-g'] + self.original_arguments
+            javac_cmd = ['javac', '-verbose', '-g', '-J-Duser.language=en'] + self.original_arguments
 
             with tempfile.NamedTemporaryFile(
                     mode='w',


### PR DESCRIPTION
This patch forces javac to report verbose output in English.

In my environment, the debug report in Japanese had caused Parsing.Parse_error at
https://github.com/facebook/infer/blob/master/infer/src/java/jClasspath.ml#L108.

This patch solved the error I encountered on compiling Hello.java.
I think `$ infer -- javac -J-Duser.language=ja Hello.java` will reproduce my bug if system supports the language. (My patch will not work with this case since the argument-specified language will override the language setting.)

Possible related issue: #30