### PR TITLE
Handle java sources from a file

### DIFF
--- a/infer/bin/inferlib.py
+++ b/infer/bin/inferlib.py
@@ -177,7 +177,7 @@ def create_results_dir(results_dir):
 
 def clean_infer_out(infer_out):
 
-    directories = ['multicore', 'classnames', 'sources']
+    directories = ['multicore', 'classnames', 'sources', 'filelists']
     extensions = ['.cfg', '.cg']
 
     for root, dirs, files in os.walk(infer_out):

--- a/infer/lib/capture/gradle.py
+++ b/infer/lib/capture/gradle.py
@@ -2,6 +2,7 @@ import os
 import util
 import logging
 import subprocess
+import tempfile
 
 MODULE_NAME = __name__
 MODULE_DESCRIPTION = '''Run analysis of code built with a command like:
@@ -11,6 +12,7 @@ Analysis examples:
 infer -- gradle build
 infer -- ./gradlew build'''
 
+FILELISTS = 'filelists'
 
 def gen_instance(*args):
     return GradleCapture(*args)
@@ -28,6 +30,9 @@ class GradleCapture:
         self.build_cmd = [cmd[0], '--debug'] + cmd[1:]
         # That contains javac version as well
         version_str = util.run_cmd_ignore_fail([cmd[0], '--version'])
+        path = os.path.join(self.args.infer_out, FILELISTS)
+        if not os.path.exists(path):
+            os.mkdir(path)
         logging.info("Running with:\n" + version_str)
 
     def get_inferJ_commands(self, verbose_output):
@@ -37,9 +42,25 @@ class GradleCapture:
             if argument_start_pattern in line:
                 content = line.partition(argument_start_pattern)[2].strip()
                 javac_arguments = content.split(' ')
-                capture = util.create_inferJ_command(self.args,
-                                                     javac_arguments)
-                calls.append(capture)
+                java_files = []
+                java_args = []
+                for java_arg in javac_arguments:
+                    if java_arg.endswith('.java'):
+                        java_files.append(java_arg)
+                    else:
+                        java_args.append(java_arg)
+                with tempfile.NamedTemporaryFile(
+                    mode='w',
+                    suffix='.txt',
+                    prefix='gradle_',
+                    dir=os.path.join(self.args.infer_out, FILELISTS),
+                    delete=False) as sources:
+                        sources.write("\n".join(java_files))
+                        sources.flush()
+                        java_args.append("@" + sources.name)
+                        capture = util.create_inferJ_command(self.args,
+                                                     java_args)
+                        calls.append(capture)
         return calls
 
     def capture(self):


### PR DESCRIPTION
The current way gradle plugin works is by parsing the verbose output to figure out which files to compile. This becomes a problem when the number of files exceed allowed argument parameter
length. Use javac's @sources file instead.

This patch will leave the tempfiles behind (also noted by Jyrki during the review), however I would like to leave that to a follow up commit and first make sure the tool works for people experiencing this problem.

Fixes #22 