### PR TITLE
Indent json files

### DIFF
--- a/infer/bin/BuckAnalyze
+++ b/infer/bin/BuckAnalyze
@@ -437,7 +437,7 @@ def collect_results(args, start_time):
 
     stats_filename = os.path.join(args.infer_out, utils.STATS_FILENAME)
     with open(stats_filename, 'w') as stats_out:
-        json.dump(stats, stats_out)
+        json.dump(stats, stats_out, indent=2)
 
     basic_stats = get_basic_stats(stats)
 

--- a/infer/bin/inferlib.py
+++ b/infer/bin/inferlib.py
@@ -626,7 +626,7 @@ class Infer:
         self.stats['normal']['infer_version'] = utils.infer_version()
 
         with open(stats_path, 'w') as stats_file:
-            json.dump(self.stats, stats_file)
+            json.dump(self.stats, stats_file, indent=2)
 
     def close(self):
         if self.args.analyzer != COMPILE:

--- a/infer/bin/utils.py
+++ b/infer/bin/utils.py
@@ -346,7 +346,7 @@ def create_json_report(out_dir):
     with open(json_report_filename, 'w') as file_out:
         headers = rows[0]
         issues = rows[1:]
-        json.dump([dict(zip(headers, row)) for row in issues], file_out)
+        json.dump([dict(zip(headers, row)) for row in issues], file_out, indent=2)
 
 
 class AbsolutePathAction(argparse.Action):


### PR DESCRIPTION
The json files that were written by json.dump were valid, machine readable but they had no indentation/return lines making them a long single line and hard to read. Dump the json with an indent of
2.