### PR TITLE
Add Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.02 PACKAGE=infer
+os:
+  - linux
+  - osx


### PR DESCRIPTION
This pull request adds a very basic Travis CI setup for the Infer repository.

Currently all is does is test to ensure Infer can build (currently, master does not build :disappointed:).

Going forward this can also run tests, I just wasn’t sure of the exact commands to run the unit tests.

This does require the repository owner to enable Travis CI for the Infer repo, but it looks like Facebook is already doing this for a number of other open source projects.