### PR TITLE
Add the opam modules required by build-infer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,7 @@ release](http://fbinfer.com/docs/getting-started.html) (faster), or to
 compile everything from source (see the end of this document).
 
 - opam >= 1.2.0
+- Install opam modules `opam install ocamlfind atdgen camlzip extlib javalib sawja`
 - Python 2.7
 - Java (only needed for the Java analysis)
 - gcc >= 4.7.2 or clang >= 3.1 (only needed for the C/Objective-C analysis)


### PR DESCRIPTION
While installing infer on MacOS X, build-infer.sh failed many times due to many missing opam modules.

The change specifies the list of opam modules that need to be installed in order to get build-infer.sh succeeding.