### PR TITLE
Target JDK 1.7 for annotations and processor jar for Android.

### DIFF
--- a/infer/annotations/Makefile
+++ b/infer/annotations/Makefile
@@ -14,6 +14,7 @@ ANNOT_SOURCES = $(shell find com/facebook/infer/annotation -name "*.java")
 PROCESSOR_SOURCES = $(shell find com/facebook/infer/annotprocess -name "*.java")
 ANNOT_CLASSES = 'annot_classes'
 PROCESSOR_CLASSES = 'processor_classes'
+TARGET_JDK_VERSION = '1.7'
 
 ANNOTATIONS_JAR = $(CWD)/annotations.jar
 PROCESSOR_JAR = $(JAVA_LIB_DIR)/processor.jar
@@ -22,12 +23,12 @@ all: $(ANNOTATIONS_JAR) $(PROCESSOR_JAR)
 
 $(ANNOTATIONS_JAR): $(ANNOT_SOURCES)
 	mkdir -p $(ANNOT_CLASSES)
-	javac -cp $(JSR_JAR) $(ANNOT_SOURCES) -d $(ANNOT_CLASSES)
+	javac -source $(TARGET_JDK_VERSION) -target $(TARGET_JDK_VERSION) -cp $(JSR_JAR) $(ANNOT_SOURCES) -d $(ANNOT_CLASSES)
 	cd $(ANNOT_CLASSES) && jar cvf $(ANNOTATIONS_JAR) com
 
 $(PROCESSOR_JAR): $(PROCESSOR_SOURCES)
 	mkdir -p $(PROCESSOR_CLASSES)
-	javac $(PROCESSOR_SOURCES) -cp .:$(JAVA_HOME)/lib/tools.jar -d $(PROCESSOR_CLASSES)
+	javac -source $(TARGET_JDK_VERSION) -target $(TARGET_JDK_VERSION) $(PROCESSOR_SOURCES) -cp .:$(JAVA_HOME)/lib/tools.jar -d $(PROCESSOR_CLASSES)
 	jar cvMf processor.jar -C resources META-INF -C $(PROCESSOR_CLASSES) com
 	mv processor.jar $(PROCESSOR_JAR)
 


### PR DESCRIPTION
The annotations won't work on Android unless you target JDK 1.7 (otherwise it can't DEX the app or library).