### PR TITLE
Add android.app.Service to whitelisted Android initializer classes.

### DIFF
--- a/infer/src/checkers/patternMatch.ml
+++ b/infer/src/checkers/patternMatch.ml
@@ -234,6 +234,7 @@ let initializer_classes =
       "android.app.Activity";
       "android.app.Application";
       "android.app.Fragment";
+      "android.app.Service";
       "android.support.v4.app.Fragment";
     ]
 


### PR DESCRIPTION
It has a similar lifecycle to activities and fragments, it would be nice to support `onCreate` as an initializer by default.