### PR TITLE
Solve failure in 'docker build .'.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN INFER_VERSION=$(curl -s https://api.github.com/repos/facebook/infer/releases
 # Compile Infer
 RUN cd /infer && \
     eval $(opam config env) && \
+    ./configure && \
     make -C infer clang java
 
 # Install Infer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,8 +34,7 @@ RUN curl -sL \
       https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-Linux \
       -o /usr/local/bin/opam && \
     chmod 755 /usr/local/bin/opam
-RUN opam init -y --comp=4.01.0 && \
-    opam switch 4.02.3 && \
+RUN opam init -y --comp=4.02.3 && \
     opam install -y extlib.1.5.4 atdgen.1.6.0 javalib.2.3.1 sawja.1.5.1
 
 # Download the latest Infer release

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN curl -sL \
       -o /usr/local/bin/opam && \
     chmod 755 /usr/local/bin/opam
 RUN opam init -y --comp=4.01.0 && \
+    opam switch 4.02.3 && \
     opam install -y extlib.1.5.4 atdgen.1.6.0 javalib.2.3.1 sawja.1.5.1
 
 # Download the latest Infer release


### PR DESCRIPTION
An issue facebook/infer#270 suggest two docker build failure error.
facebok/infer#270 issues two docker build failure errors.
- failure in 'make -C infer clang java' : add './configure' before the command.
- failure in building sources : add 'opam switch 4.02.3' to use this syntax in ' https://github.com/kstreee/infer/blob/cc4439938e99a27d301a2d42aa3413849dc55a46/infer/src/clang/cLocation.ml#L76 '. In ubuntu, when 'apt-get install ocaml' ( https://github.com/kstreee/infer/blob/cc4439938e99a27d301a2d42aa3413849dc55a46/docker/Dockerfile#L20 ), for now, it installs ocaml 4.01, but this syntax does not work with ocaml 4.01.