### PR TITLE
Make Java config test exit so it doesn't hang on some JVMs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,7 @@ if test "x$enable_java_analyzers" = "xyes"; then
 public class conftest {
   public static void main(String[[]] args) {
     System.out.println(System.getProperty("java.home"));
+    System.exit(0);
   }
 }
 _ACEOF


### PR DESCRIPTION
Was trying this article out and noticed it hung on the ./configure when trying to read JAVA_HOME:
https://medium.com/@Rapchik/static-analysis-build-server-for-android-with-jenkins-using-docker-bda888d4b34e#.dci57csez

Adding this fixed it...not sure why the JVM didn't just cleanly exit but apparently the openJDK JVM does this :-P
