### PR TITLE
[facebook/infer#288] Fix missing imoprt statement bug.

### DIFF
--- a/infer/lib/python/inferlib/capture/mvn.py
+++ b/infer/lib/python/inferlib/capture/mvn.py
@@ -10,6 +10,8 @@ import logging
 import re
 import util
 
+from inferlib import jwlib
+
 MODULE_NAME = __name__
 MODULE_DESCRIPTION = '''Run analysis of code built with a command like:
 mvn [options] [task]


### PR DESCRIPTION
Exception is raised because of missing import statment for ```jwlib```, facebook/infer#288.