### PR TITLE
Add SuppressViewNullability annotation

### DIFF
--- a/infer/annotations/com/facebook/infer/annotation/SuppressViewNullability.java
+++ b/infer/annotations/com/facebook/infer/annotation/SuppressViewNullability.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2004 - present Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.infer.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * View can be annotated with @SuppressViewNullability to silence warnings when
+ * a view is set to null in a destructor, and created in an initializer.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface SuppressViewNullability {}

--- a/infer/src/checkers/annotations.ml
+++ b/infer/src/checkers/annotations.ml
@@ -140,12 +140,14 @@ let ia_is_initializer ia =
   ia_ends_with ia initializer_
 
 let ia_is_inject ia =
-  ia_ends_with ia inject
+  IList.exists
+    (ia_ends_with ia)
+    [inject; inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
 
 let ia_is_inject_view ia =
   IList.exists
     (ia_ends_with ia)
-    [inject; inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
+    [inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
 
 let ia_is_mutable ia =
   ia_ends_with ia mutable_

--- a/infer/src/checkers/annotations.ml
+++ b/infer/src/checkers/annotations.ml
@@ -98,6 +98,10 @@ let initializer_ = "Initializer"
 let inject = "Inject"
 let inject_view = "InjectView"
 let bind = "Bind"
+let bind_array = "BindArray"
+let bind_bitmap = "BindBitmap"
+let bind_drawable = "BindDrawable"
+let bind_string = "BindString"
 let suppress_view_nullability = "SuppressViewNullability"
 let false_on_null = "FalseOnNull"
 let mutable_ = "Mutable"
@@ -138,7 +142,7 @@ let ia_is_initializer ia =
 let ia_is_inject ia =
   IList.exists
     (ia_ends_with ia)
-    [inject; inject_view; bind; suppress_view_nullability]
+    [inject; inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
 
 let ia_is_inject_view ia =
   IList.exists

--- a/infer/src/checkers/annotations.ml
+++ b/infer/src/checkers/annotations.ml
@@ -140,14 +140,12 @@ let ia_is_initializer ia =
   ia_ends_with ia initializer_
 
 let ia_is_inject ia =
-  IList.exists
-    (ia_ends_with ia)
-    [inject; inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
+  ia_ends_with ia inject
 
 let ia_is_inject_view ia =
   IList.exists
     (ia_ends_with ia)
-    [inject_view; bind; suppress_view_nullability]
+    [inject; inject_view; bind; bind_array; bind_bitmap; bind_drawable; bind_string; suppress_view_nullability]
 
 let ia_is_mutable ia =
   ia_ends_with ia mutable_

--- a/infer/src/checkers/annotations.ml
+++ b/infer/src/checkers/annotations.ml
@@ -141,7 +141,9 @@ let ia_is_inject ia =
     [inject; inject_view; bind; suppress_view_nullability]
 
 let ia_is_inject_view ia =
-  ia_ends_with ia inject_view
+  IList.exists
+    (ia_ends_with ia)
+    [inject_view; bind; suppress_view_nullability]
 
 let ia_is_mutable ia =
   ia_ends_with ia mutable_

--- a/infer/src/checkers/annotations.ml
+++ b/infer/src/checkers/annotations.ml
@@ -98,6 +98,7 @@ let initializer_ = "Initializer"
 let inject = "Inject"
 let inject_view = "InjectView"
 let bind = "Bind"
+let suppress_view_nullability = "SuppressViewNullability"
 let false_on_null = "FalseOnNull"
 let mutable_ = "Mutable"
 let nullable = "Nullable"
@@ -137,7 +138,7 @@ let ia_is_initializer ia =
 let ia_is_inject ia =
   IList.exists
     (ia_ends_with ia)
-    [inject; inject_view; bind]
+    [inject; inject_view; bind; suppress_view_nullability]
 
 let ia_is_inject_view ia =
   ia_ends_with ia inject_view

--- a/infer/tests/codetoanalyze/java/eradicate/FieldNotInitialized.java
+++ b/infer/tests/codetoanalyze/java/eradicate/FieldNotInitialized.java
@@ -33,6 +33,8 @@ public class FieldNotInitialized {
 
   @Bind(42) EditText f;
 
+  @SuppressViewNullability @NonNull EditText g;
+
   //  Eradicate should only report one initialization error
   FieldNotInitialized() {}
 


### PR DESCRIPTION
This pull request adds the @SuppressViewNullability annotation. 

The reasoning behind this is that in libraries, one cannot use Butterknife for view binding, which forces you to do it manually. Basically, this makes a new annotation that infer treats the same way as @Bind/@InjectView 