### PR TITLE
add build instructions for Debian 8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,6 +118,29 @@ sudo apt-get install -y \
   zlib1g-dev
 ```
 
+### Debian 8
+
+```sh
+sudo apt install -y \
+  autoconf \
+  automake \
+  build-essential \
+  git \
+  libgmp-dev \
+  libmpc-dev \
+  libmpfr-dev \
+  m4 \
+  openjdk-7-jdk \
+  unzip \
+  zlib1g-dev \
+  opam \
+  rsync \
+  pkg-config \
+  libncurses-dev \
+  python \
+  aspcud
+```
+
 ### Ubuntu 12.04.4 LTS
 
 ```sh


### PR DESCRIPTION
I was able to build infer on a clean Debian 8 Jessie chroot with the packages above.

Possibly some packages might be added to other Debian-based distros, I can followup with another PR.