### PR TITLE
Modify existing example of adding checker

### DIFF
--- a/_docs/04-adding-checkers.md
+++ b/_docs/04-adding-checkers.md
@@ -9,7 +9,7 @@ permalink: /docs/adding-checkers.html
 
 Infer Checkers provide a framework to perform intra-procedural static analyses.
 Since this is an open source project, everyone is welcome to contribute with new great checkers.
-In this page, we will create a very basic checker - a detector for every time the output method ```PrintStream.println``` is called.
+In this page, we will create a very basic checker - a detector for every time the output method ```java.io.PrintStream.println``` is called.
 This should be enough to get you started.
 
 ## Before you start
@@ -89,63 +89,52 @@ let callback_my_simple_checker { Callbacks.proc_desc; proc_name } =
   Cfg.Procdesc.iter_instrs do_instr proc_desc
 
 ```
+The `checkers/PatternMatch.ml` module contains the `java_proc_name_with_class_method` function which we can use for matching the required pattern.
 
-Each node is represented using the type ```instr``` from the Smallfoot Intermediate Language (SIL). Take a look at ```sil.mli``` to get familiar with all the types. All source code languages supported by Infer are converted to this representation.
+Each node is represented using the type ```instr``` from the Smallfoot Intermediate Language (SIL). Take a look at ```IR/sil.rei``` to get familiar with all the types. All source code languages supported by Infer are converted to this representation.
 
 In this particular example, `Sil.Call` has the following information:
 
 ```ocaml
 Sil.Call (
 	list_of_return_values,
-	Sil.Const (Sil.Cfun name_of_function),
+	Sil.Const (Const.Cfun name_of_function),
 	list_of_arguments,
 	location,
 	call_flags
 )
 ```
 
-I hope this looks straight forward. Argument ```call_flags``` holds information about the function, such as whether it is virtual or not. Again, this is specified in the file ```sil.mli```.
+I hope this looks straight forward. Argument ```call_flags``` holds information about the function, such as whether it is virtual or not. Again, this is specified in the file ```sil.rei```.
 
-The Checker we have written so far is able to detect every single function call. Now, we have to detect whether a specific function call is actually calling ```Printstream.println```.
+The Checker we have written so far is able to detect every single function call. Now, we have to detect whether a specific function call is actually calling ```java.io.PrintStream.println```.
 
 Let's try this:
 
 ```ocaml
+(** Simple Checker *)
 let callback_my_simple_checker { Callbacks.proc_desc; proc_name } =
+  let is_println pln = match pln with
+    | Procname.Java pn_java ->
+        PatternMatch.java_proc_name_with_class_method
+          pn_java "java.io.PrintStream" "println"
+    | _ ->
+        false in
   let do_instr node = function
-    | Sil.Call (_, Sil.Const (Sil.Cfun pn), _, loc, _) when Procname.java_is_print_method pn->
+    | Sil.Call (_, Sil.Const (Const.Cfun pn), _, loc, _) when is_println pn->
+        L.err "Sample Log Message %a@." Procname.pp proc_name;
         ST.report_error
           proc_name
           proc_desc
           "CHECKERS_MY_SIMPLE_CHECKER"
-          location
+          loc
           "A description of my simple checker"
     | _ -> () in
   Cfg.Procdesc.iter_instrs do_instr proc_desc
 
 ```
 
-Can you spot the difference? A new restriction was added to our pattern -- ```Procname.java_is_print_method``` will tell whether this specific function call is a ```println``` function.
-
-```Procname``` module implements several utility functions that are useful for this kind of analysis. However, this particular one ```java_is_print_method``` is not implemented yet.
-
-In file ```procname.ml``` add the following function:
-
-```ocaml
-(** [java_is_print_method pn] returns true if [pn] is an output method **)
-let java_is_print_method = function
-	| Java js ->
-		let _, class_name = js.class_name in
-		(js.method_name = "println") && (class_name = "PrintStream")
-	| _ -> false
-```
-
-And in file ```procname.mli``` add the respective signature:
-
-```ocaml
-(** [java_is_print_method pn] returns true if [pn] is an output method **)
-val java_is_print_method : t -> bool
-```
+Can you spot the difference? A new restriction was added to our pattern -- ```is_println``` expression helps us to check whether the current method is a ```java.io.PrintStream.println``` method or not.
 
 So our implementation is done.
 Now we have to register it as an enabled Checker.
@@ -195,4 +184,3 @@ Notice that only ```System.out.println``` is being detected.
 
 All set! You are ready to create your own Checkers!
 Infer is an open source project and you are more than welcome to contribute. Take a look at the  [Github](https://github.com/facebook/infer/) page and feel free to fork or even open an issue if you're facing any trouble.
-

--- a/_docs/04-adding-checkers.md
+++ b/_docs/04-adding-checkers.md
@@ -91,7 +91,7 @@ let callback_my_simple_checker { Callbacks.proc_desc; proc_name } =
 ```
 The `checkers/PatternMatch.ml` module contains the `java_proc_name_with_class_method` function which we can use for matching the required pattern.
 
-Each node is represented using the type ```instr``` from the Smallfoot Intermediate Language (SIL). Take a look at ```IR/sil.rei``` to get familiar with all the types. All source code languages supported by Infer are converted to this representation.
+Each node is represented using the type ```instr``` from the Smallfoot Intermediate Language (SIL). Take a look at ```IR/Sil.rei``` to get familiar with all the types. All source code languages supported by Infer are converted to this representation.
 
 In this particular example, `Sil.Call` has the following information:
 
@@ -105,7 +105,7 @@ Sil.Call (
 )
 ```
 
-I hope this looks straight forward. Argument ```call_flags``` holds information about the function, such as whether it is virtual or not. Again, this is specified in the file ```sil.rei```.
+I hope this looks straight forward. Argument ```call_flags``` holds information about the function, such as whether it is virtual or not. Again, this is specified in the file ```Sil.rei```.
 
 The Checker we have written so far is able to detect every single function call. Now, we have to detect whether a specific function call is actually calling ```java.io.PrintStream.println```.
 


### PR DESCRIPTION
The example of [adding-checker](http://fbinfer.com/docs/adding-checkers.html) uses an old revision for explanation. I have used a function defined in `patternMatch.ml` to replicate the use using the latest revision.