### PR TITLE
Fix ascii codec can't decode utf8

### DIFF
--- a/infer/lib/python/inferlib/capture/util.py
+++ b/infer/lib/python/inferlib/capture/util.py
@@ -24,7 +24,7 @@ def get_build_output(build_cmd):
     #  TODO make it return generator to be able to handle large builds
     proc = subprocess.Popen(build_cmd, stdout=subprocess.PIPE)
     (verbose_out_chars, _) = proc.communicate()
-    return utils.decode(verbose_out_chars).split('\n')
+    return utils.decode(verbose_out_chars).decode('UTF-8').split('\n')
 
 
 def run_compilation_commands(cmds, clean_cmd):


### PR DESCRIPTION
Fix Issue https://github.com/facebook/infer/issues/387

There is a error that python2.x not support ascii as default
so we got 
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 2944712: ordinal not in range(128)
```