### PR TITLE
Add path filter

### DIFF
--- a/infer/src/backend/config.ml
+++ b/infer/src/backend/config.ml
@@ -60,10 +60,14 @@ type method_pattern = {
   parameters : (string list) option;
 }
 
+type path_patterns = {
+  paths : (string list);
+}
+
 type pattern =
   | Method_pattern of language * method_pattern
   | Source_contains of language * string
-
+  | Path_patterns of path_patterns
 
 type zip_library = {
   zip_filename: string;
@@ -275,6 +279,10 @@ let patterns_of_json_with_key json_key json =
 
   let default_source_contains = "" in
 
+  let default_path_patterns = {
+    paths = []
+  } in
+
   let language_of_string = function
     | "Java" ->
         Ok Java
@@ -296,12 +304,15 @@ let patterns_of_json_with_key json_key json =
     match detect_language assoc with
     | Ok language ->
         let is_method_pattern key = IList.exists (string_equal key) ["class"; "method"]
+        and is_path_pattern key = IList.exists (string_equal key) ["paths"]
         and is_source_contains key = IList.exists (string_equal key) ["source_contains"] in
         let rec loop = function
           | [] ->
               Error ("Unknown pattern for " ^ json_key ^ " in " ^ inferconfig_file)
           | (key, _) :: _ when is_method_pattern key ->
               Ok (Method_pattern (language, default_method_pattern))
+          | (key, _) :: _ when is_path_pattern key ->
+              Ok (Path_patterns (default_path_patterns))
           | (key, _) :: _ when is_source_contains key ->
               Ok (Source_contains (language, default_source_contains))
           | _:: tl -> loop tl in
@@ -327,6 +338,10 @@ let patterns_of_json_with_key json_key json =
         | (key, _) when key = "language" -> mp
         | _ -> failwith ("Fails to parse " ^ Yojson.Basic.to_string (`Assoc assoc)) in
       IList.fold_left loop default_method_pattern assoc
+    and create_path_patterns assoc =
+      let loop pp = function
+        | (key, `List l) when key = "paths" -> (collect_params l) in
+      loop default_path_patterns assoc
     and create_string_contains assoc =
       let loop sc = function
         | (key, `String pattern) when key = "source_contains" -> pattern
@@ -904,7 +919,8 @@ and margin =
 and (
   patterns_modeled_expensive,
   patterns_never_returning_null,
-  patterns_skip_translation) =
+  patterns_skip_translation,
+  patterns_skip_translation_path) =
   let mk_option ~deprecated ~long doc =
     CLOpt.mk_set_from_json ~deprecated ~long ~default:[] ~default_to_string:(fun _ -> "[]")
       ~exes:CLOpt.[Java]
@@ -915,7 +931,9 @@ and (
     mk_option ~deprecated:["never_returning_null"] ~long:"never-returning-null"
       "Matcher or list of matchers for functions that never return `null`.",
     mk_option ~deprecated:["skip_translation"] ~long:"skip-translation"
-      "Matcher or list of matchers for names of files that should be analyzed at all.")
+      "Matcher or list of matchers for names of files that should be analyzed at all.",
+      mk_option ~deprecated:["skip_translation_path"] ~long:"skip-translation"
+      "Matcher or list of matchers for paths of files that should be analyzed at all.")
 
 and pmd_xml =
   CLOpt.mk_bool ~long:"pmd-xml"
@@ -1444,6 +1462,7 @@ and optimistic_cast = !optimistic_cast
 and out_file_cmdline = !out_file
 and patterns_never_returning_null = !patterns_never_returning_null
 and patterns_skip_translation = !patterns_skip_translation
+and patterns_skip_translation_path = !patterns_skip_translation_path
 and patterns_modeled_expensive = !patterns_modeled_expensive
 and pmd_xml = !pmd_xml
 and precondition_stats = !precondition_stats

--- a/infer/src/backend/config.mli
+++ b/infer/src/backend/config.mli
@@ -43,9 +43,14 @@ type method_pattern = {
   parameters : (string list) option;
 }
 
+type path_patterns = {
+  paths : (string list);
+}
+
 type pattern =
   | Method_pattern of language * method_pattern
   | Source_contains of language * string
+  | Path_patterns of path_patterns
 
 
 type zip_library = {
@@ -101,6 +106,7 @@ val os_type : os_type
 val patterns_modeled_expensive : pattern list
 val patterns_never_returning_null : pattern list
 val patterns_skip_translation : pattern list
+val patterns_skip_translation_path : pattern list
 val patterns_suppress_warnings : pattern list
 val perf_stats_prefix : string
 val proc_stats_filename : string

--- a/infer/src/backend/inferconfig.mli
+++ b/infer/src/backend/inferconfig.mli
@@ -34,6 +34,7 @@ val create_filters : Config.analyzer -> filters
 val never_return_null_matcher : DB.source_file -> Procname.t -> bool
 val suppress_warnings_matcher : DB.source_file -> Procname.t -> bool
 val skip_translation_matcher : DB.source_file -> Procname.t -> bool
+val skip_translation_path_matcher : DB.source_file -> Procname.t -> bool
 val modeled_expensive_matcher : (string -> bool) -> Procname.t -> bool
 
 (** Load the config file and list the files to report on *)

--- a/infer/src/java/jMain.ml
+++ b/infer/src/java/jMain.ml
@@ -127,9 +127,10 @@ let do_all_files classpath sources classes =
   let tenv = load_tenv () in
   let linereader = Printer.LineReader.create () in
   let skip source_file = Inferconfig.skip_translation_matcher source_file Procname.empty_block in
+  let skip_path source_file = Inferconfig.skip_translation_path_matcher source_file Procname.empty_block in
   let translate_source_file basename (package_opt, _) source_file =
     init_global_state source_file;
-    if not (skip source_file) then
+    if not (skip source_file) && not (skip_path source_file) then
       do_source_file linereader classes program tenv basename package_opt source_file in
   StringMap.iter
     (fun basename file_entry ->


### PR DESCRIPTION
Ref #454

@jeremydubreil I got it close to a point where it can be finished up to merge. Im no ocaml expert and just based my code off the other existing ones.

Please let me know if something is completely off and what I should do to fix the last few compiler errors.

This will let us exclude entire paths like `buck-out/annotation` which contain all generated code and greatly improve infer run speeds

Thanks!