### PR TITLE
There doesn't appear to be any 0.9.4 release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN VERSION=1.2.2; \
 RUN opam init -y --comp=4.02.3
 
 # Download the latest Infer release
-RUN INFER_VERSION=v0.9.4; \
+RUN INFER_VERSION=v0.9.3; \
     cd /opt && \
     curl -sL \
       https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz | \


### PR DESCRIPTION
Hi Facebook team - I just tried to install infer via the offered Dockerfile, and it failed with...

    Step 8 : RUN INFER_VERSION=v0.9.4;     cd /opt &&     curl -sL https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz |     tar xJ &&     rm -f /infer &&     ln -s ${PWD}/infer-linux64-$INFER_VERSION /infer
     ---> Running in 11442e175368
    xz: (stdin): File format not recognized
    tar: Child returned status 1
    tar: Error is not recoverable: exiting now
    The command '/bin/sh -c INFER_VERSION=v0.9.4;     cd /opt &&     curl -sL https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz |     tar xJ &&     rm -f /infer &&     ln -s ${PWD}/infer-linux64-$INFER_VERSION /infer' returned a non-zero code: 2

This patch just makes the Dockerfile point to release 0.9.3 - which actually exists.