### PR TITLE
Clarify gradle command for Android Studio

### DIFF
--- a/_docs/01-analyzing-apps-or-projects.md
+++ b/_docs/01-analyzing-apps-or-projects.md
@@ -15,12 +15,18 @@ get more information about how a particular build system is supported
 by running `infer --help -- <build system>`, for instance `infer
 --help -- gradle`.
 
-### Gradle
+### Gradle / Android Studio
+
+```bash
+cd My_Android_App/Folder_that_contains_gradlew
+infer -- ./gradlew build   # Format is: infer -- ./gradlew <gradle task, e.g. "build">
+```
+or
 
 ```bash
 infer -- gradle <gradle task, e.g. "build">
-infer -- ./gradlew <gradle task, e.g. "build">
 ```
+
 
 ### Buck
 


### PR DESCRIPTION
The user must cd into the folder that contains 'gradlew' first, and then run the command, otherwise it doesn't work.
Also, the 2nd version of the command: "infer -- gradle build", does not seem to work for me. So move the working version to the top.