### PR TITLE
Update build-infer.sh

### DIFF
--- a/build-infer.sh
+++ b/build-infer.sh
@@ -98,10 +98,10 @@ check_installed () {
 setup_opam () {
     OCAML_VERSION="4.02.3"
 
-    opam init --compiler=$OCAML_VERSION -j $NCPU --no-setup --yes
+    opam init --comp=$OCAML_VERSION -j $NCPU --no-setup --yes
 
     OPAMSWITCH=infer-$OCAML_VERSION
-    opam switch set -j $NCPU $OPAMSWITCH --alias-of $OCAML_VERSION
+    opam switch $OPAMSWITCH -j $NCPU --alias-of=$OCAML_VERSION
 }
 
 add_opam_git_pin () {


### PR DESCRIPTION
The guidelines say I make sure infer builds, but this PR is exactly to fix a tiny issue with the build-infer.sh script. Changes are numbered below:

1. **opam init**: '--compiler' option has been changed to '--comp' (ref: https://github.com/ocaml/opam/commit/36a5d5f5a68d29b882bd4a584f66c0ae18235c6c)
   
2. **opam switch**: was giving 'too many arguments' error. The 'set' submenu is optional now, so I just removed that and rearranged arguments order