### PR TITLE
Add an option to skip updating submodules if only building for java

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,7 +12,7 @@ set -e
 # try to pull submodules if we are in a git repo
 # might fail if git is not installed (how did you even checkout the
 # repo in the first place?)
-if test -d '.git'; then
+if test -d '.git' && [[ -z "$SKIP_SUBMODULES" ]] ; then
   printf 'git repository detected, updating submodule... '
   git submodule update --init > /dev/null
   printf 'done\n'

--- a/build-infer.sh
+++ b/build-infer.sh
@@ -135,7 +135,11 @@ install_opam_deps
 
 echo "preparing build... "
 if [ ! -f .release ]; then
-  ./autogen.sh > /dev/null
+  if [ "$BUILD_CLANG" = "no" ]; then
+    SKIP_SUBMODULES=true ./autogen.sh > /dev/null
+  else
+    ./autogen.sh > /dev/null
+  fi
 fi
 
 if [ "$BUILD_CLANG" = "no" ]; then


### PR DESCRIPTION
When invoking `./build-infer.sh java`, there is no need to update the facebook-clang-plugins submodule that is done as part of the `autogen.sh` script. The submodule update takes a very long time and can be skipped when building only for java