### PR TITLE
Cleanup DEFS file for generating infer genrules

### DIFF
--- a/DEFS
+++ b/DEFS
@@ -1,5 +1,7 @@
 import os
 
+analyzers = ['infer', 'eradicate']
+
 original_java_library = java_library
 def java_library(
     name,
@@ -13,17 +15,40 @@ def java_library(
     **kwargs
   )
 
+  create_genrules(name, srcs)
+
+original_android_library = android_library
+def android_library(
+    name,
+    srcs=[],
+    **kwargs
+    ):
+
+  original_android_library(
+    name=name,
+    srcs=srcs,
+    **kwargs
+  )
+
+  create_genrules(name, srcs)
+
+def create_genrules(
+    name,
+    srcs
+    ):
   if 'GENERATE_INFER_GENRULES' in os.environ and srcs:
-    infer_name = name + '_infer'
-    genrule(
-      name = infer_name,
-      srcs=srcs,
-      cmd = ' '.join([
-        os.getenv('INFER_BIN', 'infer'),
-        '--results-dir', '$OUT',
-        '--classpath', '$(classpath :{})'.format(name),
-        '--sourcepath $SRCDIR',
-        '--generated-classes', '$(location :{})'.format(name),
-      ]),
-      out = 'infer_out',
-    )
+    for analyzer in analyzers:
+      analyzer_name = name + '_{}'.format(analyzer)
+      genrule(
+        name = analyzer_name,
+        srcs=srcs,
+        cmd = ' '.join([
+          os.getenv('INFER_BIN', 'infer'),
+          '-a', analyzer,
+          '--results-dir', '$OUT',
+          '--classpath', '$(classpath :{})'.format(name),
+          '--sourcepath', '$SRCDIR',
+          '--generated-classes', '$(location :{})'.format(name),
+        ]),
+        out = '{}_out'.format(analyzer),
+      )

--- a/DEFS
+++ b/DEFS
@@ -3,44 +3,27 @@ import os
 original_java_library = java_library
 def java_library(
     name,
-    deps=[],
+    srcs=[],
     **kwargs
     ):
-  compile_name = name + '_compile'
-  top_deps = []
-
-  if 'GENERATE_INFER_GENRULES' in os.environ:
-    export_srcs_name = name + '_export_srcs'
-    genrule(
-      name = export_srcs_name,
-      srcs = kwargs.get('srcs', []),
-      cmd = 'mkdir -p $OUT && cp -R $SRCDIR/* $OUT/',
-      out = 'src_copy',
-    )
-    infer_name = name + '_infer'
-    genrule(
-      name = infer_name,
-      cmd = ' '.join([
-        os.getenv('INFER_BIN', 'infer'),
-        '--results-dir', '$OUT',
-        '--classpath', '$(classpath :{})'.format(compile_name),
-        '--sourcepath', '$(location :{})'.format(export_srcs_name),
-        '--generated-classes', '$(location :{})'.format(compile_name),
-      ]),
-      out = 'infer_out',
-    )
-    top_deps += [':' + infer_name, ':' + export_srcs_name]
 
   original_java_library(
     name=name,
-    exported_deps=[
-      ':' + compile_name,
-    ],
-    deps=top_deps,
-    visibility = kwargs.get('visibility', [])
-  )
-  original_java_library(
-    name=compile_name,
-    deps=deps,
+    srcs=srcs,
     **kwargs
   )
+
+  if 'GENERATE_INFER_GENRULES' in os.environ and srcs:
+    infer_name = name + '_infer'
+    genrule(
+      name = infer_name,
+      srcs=srcs,
+      cmd = ' '.join([
+        os.getenv('INFER_BIN', 'infer'),
+        '--results-dir', '$OUT',
+        '--classpath', '$(classpath :{})'.format(name),
+        '--sourcepath $SRCDIR',
+        '--generated-classes', '$(location :{})'.format(name),
+      ]),
+      out = 'infer_out',
+    )


### PR DESCRIPTION
- Only generate one extra genrule for running infer. Remove all other java library rules currently being generated
- Generate infer genrule only if the `java_library` has `srcs`, otherwise there is nothing to analyze
- Use `SRCDIR` to avoid making a copy of the target sources as buck will just symlink them instead
- Added support for `android_library` rules as well
- Added support to generate both `infer` and `eradicate` genrules