### PR TITLE
Excluding delegates storages from STRONG_DELEGATE_CHECK

### DIFF
--- a/infer/src/clang/cFrontend_checkers.ml
+++ b/infer/src/clang/cFrontend_checkers.ml
@@ -166,13 +166,16 @@ let ctl_strong_delegate_warning lctx an =
   let open CTL in
   let name_contains_delegate =
     Atomic ("property_name_contains_word", ["delegate"]) in
+  let name_does_not_contain_delegates =
+    Not(Atomic ("property_name_contains_word", ["delegates"])) in
   let name_does_not_contains_queue =
     Not(Atomic ("property_name_contains_word", ["queue"])) in
   let is_strong_property =
     Atomic("is_strong_property", []) in
   let condition = InNode (["ObjCPropertyDecl"], And (name_contains_delegate,
-                                                     And (name_does_not_contains_queue,
-                                                          is_strong_property))) in
+                                                And (name_does_not_contain_delegates,
+                                                And (name_does_not_contains_queue,
+                                                     is_strong_property)))) in
   let issue_desc = {
     CIssue.issue = CIssue.Strong_delegate_warning;
     CIssue.description = Printf.sprintf


### PR DESCRIPTION
Hi!
It's quite common to have collections of delegates. The collection itself is usually named like  "_delegates_Hash", "_delegates_Storage" or simply "_delegates_". Obviously, there is common part in all these cases, but currently you're excluding property only if it contains "queue".
I've added a simple exclusion by common part. It solved our warnings and I think for others it'll be quite helpful too.

P.S. I made that pull request to 0.9.5 since it is currently released version and master branch has separate rules file. I can make separate pull request for master with the same simple fix.