### PR TITLE
Added 'delegates' string to exclusions in STRONG_DELEGATE_CHECK

### DIFF
--- a/infer/lib/linter_rules/linters.al
+++ b/infer/lib/linter_rules/linters.al
@@ -138,11 +138,12 @@ DEFINE-CHECKER REGISTERED_OBSERVER_BEING_DEALLOCATED = {
 DEFINE-CHECKER STRONG_DELEGATE_WARNING = {
 
   LET name_contains_delegate = property_name_contains_word(delegate);
+  LET name_does_not_contain_delegates = NOT property_name_contains_word(delegates);
   LET name_does_not_contains_queue = NOT property_name_contains_word(queue);
 
   SET report_when =
 	    WHEN
-				name_contains_delegate AND name_does_not_contains_queue AND is_strong_property()
+				name_contains_delegate AND name_does_not_contain_delegates AND name_does_not_contains_queue AND is_strong_property()
 			HOLDS-IN-NODE ObjCPropertyDecl;
 
   SET message = "Property or ivar %decl_name% declared strong";


### PR DESCRIPTION
Hi!
It's quite common to have collections of delegates. The collection itself is usually named like "delegatesHash", "delegatesStorage" or simply "delegates". Obviously, there is common part in all these cases, but currently you're excluding property only if it contains "queue".
I've added a simple exclusion by common part. It solved false-positive warnings for me and I think for others it'll be quite helpful too.