### PR TITLE
Docker: Update to Infer v0.10.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN VERSION=1.2.2; \
 RUN opam init -y --comp=4.02.3
 
 # Download the latest Infer release
-RUN INFER_VERSION=v0.9.4.1; \
+RUN INFER_VERSION=v0.10.0; \
     cd /opt && \
     curl -sL \
       https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz | \


### PR DESCRIPTION
Given #524 was required to do the last manual update, perhaps the Dockerfile could be updated as part of the release process instead of catching it after the fact?

Cheers!