### PR TITLE
Dockerfile: add missing libffi build dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
             git \
             groff \
             libc6-dev \
+            libffi-dev \
             libgmp-dev \
             libmpc-dev \
             libmpfr-dev \


### PR DESCRIPTION
Fixes this error in the Docker image build (mentioned in https://github.com/facebook/infer/issues/570#issuecomment-282191663):

```
#=== ERROR while installing ctypes.0.11.3 =====================================#
# opam-version         1.2.2
# os                   linux
# command              make XEN=disable ctypes-foreign
# path                 /root/.opam/infer-4.02.3/build/ctypes.0.11.3
# compiler             4.02.3
# exit-code            2
# env-file             /root/.opam/infer-4.02.3/build/ctypes.0.11.3/ctypes-5557-6ff7fe.env
# stdout-file          /root/.opam/infer-4.02.3/build/ctypes.0.11.3/ctypes-5557-6ff7fe.out
# stderr-file          /root/.opam/infer-4.02.3/build/ctypes.0.11.3/ctypes-5557-6ff7fe.err
### stdout ###
# [...]
# The following required C libraries are missing: libffi.
# Please install them and retry. If they are installed in a non-standard location
# or need special flags, set the environment variables <LIB>_CFLAGS and <LIB>_LIBS
# accordingly and retry.
# 
#  For example, if libffi is installed in /opt/local, you can type:
# 
#    export LIBFFI_CFLAGS=-I/opt/local/include
#    export LIBFFI_LIBS="-L/opt/local/lib -lffi"
# Makefile:200: recipe for target 'test-libffi' failed
### stderr ###
# make: *** [test-libffi] Error 1
```