### PR TITLE
Update Android Plugin for Gradle (APG) and dependencies

### DIFF
--- a/examples/android_hello/app/build.gradle
+++ b/examples/android_hello/app/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 22
     buildToolsVersion "22.0.1"
+    
+    buildOptions.abortOnError false
 
     defaultConfig {
         applicationId "infer.inferandroidexample"

--- a/examples/android_hello/build.gradle
+++ b/examples/android_hello/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android_hello/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android_hello/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip


### PR DESCRIPTION
* Makes running Android example simpler - APG 2.2.0 automatically downloads dependencies so long as the user has previously accepted the Android SDK License. 
* APG 2.2.0 requires Gradle 2.14 or newer, so updated to latest.
* Added `buildOptions.abortOnError false` so the build doesn't report any lint issues - the sample is designed to show Infer working, not Android lint.