### PR TITLE
Dockerfile update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ MAINTAINER Infer
 # Debian config
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+            aspcud \
             autoconf \
             automake \
             gcc \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN INFER_VERSION=v0.10.0; \
 
 # Compile Infer
 RUN cd /infer && \
-    ./build-infer.sh
+    ./build-infer.sh && \
+    rm -rf /root/.opam
 
 # Install Infer
 ENV INFER_HOME /infer/infer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,11 +8,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             autoconf \
             automake \
-            curl \
             gcc \
             g++ \
             git \
-            groff \
+            groff-base \
             libc6-dev \
             libffi-dev \
             libgmp-dev \
@@ -25,11 +24,11 @@ RUN apt-get update && \
             opam \
             openjdk-8-jdk-headless \
             pkg-config \
-            python-software-properties \
+            python2.7 \
             rsync \
-            software-properties-common \
             unzip \
-            zlib1g-dev
+            zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN opam init -y --comp=4.02.3
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,8 +40,10 @@ RUN INFER_VERSION=v0.11.0; \
     ln -s ${PWD}/infer-linux64-$INFER_VERSION /infer
 
 # Compile Infer
-RUN cd /infer && \
-    ./build-infer.sh && \
+RUN OCAML_VERSION=4.04.0; \
+    opam init --compiler=$OCAML_VERSION -j $(getconf _NPROCESSORS_ONLN || echo 1) --yes && \
+    cd /infer && \
+    ./build-infer.sh --opam-switch $OCAML_VERSION && \
     rm -rf /root/.opam
 
 # Install Infer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
             make \
             ncurses-dev \
             ocaml \
+            opam \
             openjdk-8-jdk-headless \
             pkg-config \
             python-software-properties \
@@ -30,14 +31,6 @@ RUN apt-get update && \
             unzip \
             zlib1g-dev
 
-# Install OPAM
-RUN VERSION=1.2.2; \
-    curl -sL \
-      https://github.com/ocaml/opam/releases/download/$VERSION/opam-$VERSION-x86_64-Linux \
-      -o /usr/local/bin/opam && \
-    chmod 755 /usr/local/bin/opam && \
-    ((/usr/local/bin/opam --version | grep -q $VERSION) || \
-     (echo "failed to download opam from GitHub."; exit 1))
 RUN opam init -y --comp=4.02.3
 
 # Download the latest Infer release

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,13 @@
 # Base image
-FROM heikomaass/android-sdk
+FROM buildpack-deps:xenial-curl
 
 MAINTAINER Infer
-
-# Add android-22 and build-tools-22 to the Android SDK
-RUN ["/opt/sdk-tools/android-accept-licenses.sh", \
-     "android update sdk --filter \"android-22\" --no-ui --force --all"]
-RUN ["/opt/sdk-tools/android-accept-licenses.sh", \
-     "android update sdk --filter \"build-tools-22.0.1\" --no-ui --force --all"]
 
 # Debian config
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             autoconf \
+            automake \
             curl \
             gcc \
             g++ \
@@ -27,6 +22,7 @@ RUN apt-get update && \
             make \
             ncurses-dev \
             ocaml \
+            openjdk-8-jdk-headless \
             pkg-config \
             python-software-properties \
             rsync \
@@ -60,3 +56,21 @@ RUN cd /infer && \
 # Install Infer
 ENV INFER_HOME /infer/infer
 ENV PATH ${INFER_HOME}/bin:${PATH}
+
+# Install dependencies for Android sample
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+            libc6-dev \
+            libc6-i386 \
+            lib32z1 \
+            lib32stdc++6 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV ANDROID_HOME /opt/android-sdk-linux
+WORKDIR $ANDROID_HOME
+RUN curl -o sdk-tools-linux.zip \
+      https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip && \
+    unzip sdk-tools-linux.zip && \
+    rm sdk-tools-linux.zip
+ENV PATH ${ANDROID_HOME}/tools/bin:${PATH}
+RUN echo "sdk.dir=${ANDROID_HOME}" > /infer/examples/android_hello/local.properties

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
             git \
             groff-base \
             libc6-dev \
-            libffi-dev \
             libgmp-dev \
             libmpc-dev \
             libmpfr-dev \
@@ -34,7 +33,7 @@ RUN apt-get update && \
 RUN opam init -y --comp=4.02.3
 
 # Download the latest Infer release
-RUN INFER_VERSION=v0.10.0; \
+RUN INFER_VERSION=v0.11.0; \
     cd /opt && \
     curl -sL \
       https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz | \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,8 +30,6 @@ RUN apt-get update && \
             zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN opam init -y --comp=4.02.3
-
 # Download the latest Infer release
 RUN INFER_VERSION=v0.11.0; \
     cd /opt && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,6 +29,7 @@ Infer.
 ./run.sh
 # you should now be inside the docker container with a shell prompt, e.g.
 # "root@5c3b9af90d59:/infer/examples# "
+sdkmanager --licenses
 cd android_hello/
 infer -- ./gradlew build
 ```

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -48,4 +48,8 @@ fi
 NAME="infer"
 
 docker build -t $NAME . && \
+echo "*************************************************************" && \
+echo "To build the Android example, you must accept the Android SDK" && \
+echo "licenses by running 'sdkmanager --licenses' first."            && \
+echo "*************************************************************" && \
 docker run -it $NAME /bin/bash -c 'cd /infer/examples/; exec /bin/bash'


### PR DESCRIPTION
This cuts the resulting image from ~4.6GB to ~1.6GB.

Infer functionality is not sacrificed and the following commands run successfully without any extra user interaction (including Android example provided the user has accepted the Android SDK license which they'll be prompted to do when running the Docker image, see https://github.com/facebook/infer/pull/597#issuecomment-284864016):
```bash
cd /infer/examples && infer -- javac Hello.java
cd /infer/examples && infer -- gcc -c hello.c
cd /infer/examples && infer -- clang -c hello.c
cd /infer/examples/c_hello && infer -- make
cd /infer/examples/java_hello && infer -- javac Hello.java Pointers.java Resources.java
cd /infer/examples/android_hello && infer -- ./gradlew build
```

The OPAM installation is no longer retained. This may impact Infer developers if they're using the Docker images and require OPAM packages to be installed as part of their workflow.