### PR TITLE
display additional options in help text

### DIFF
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -927,8 +927,9 @@ and from_json_report =
 
 and frontend_debug =
   CLOpt.mk_bool ~long:"frontend-debug" ~short:"fd"
+    ~parse_mode:CLOpt.(Infer [Clang])
     "Emit debug info to *.o.astlog and a script *.o.sh that replays the command used to run clang \
-     with the plugin attached, piped to the InferClang frontend command (clang only)"
+     with the plugin attached, piped to the InferClang frontend command"
 
 and frontend_stats =
   CLOpt.mk_bool ~long:"frontend-stats" ~short:"fs"
@@ -1149,6 +1150,7 @@ and quiet =
 
 and reactive =
   CLOpt.mk_bool ~deprecated:["reactive"] ~long:"reactive" ~short:"r"
+    ~parse_mode:CLOpt.(Infer [Driver])
     "Reactive mode: the analysis starts from the files captured since the `infer` command started"
 
 and reactive_capture =


### PR DESCRIPTION
These are mentioned on fbinfer.com so IMHO should be displayed when running infer -h