### PR TITLE
handle an uncaught exception when converting too large integers to intervals

### DIFF
--- a/infer/src/bufferoverrun/bufferOverrunSemantics.ml
+++ b/infer/src/bufferoverrun/bufferOverrunSemantics.ml
@@ -24,7 +24,7 @@ struct
 
   let eval_const : Const.t -> Val.t
     = function
-      | Const.Cint intlit -> Val.of_int (IntLit.to_int intlit)
+      | Const.Cint intlit -> (try Val.of_int (IntLit.to_int intlit) with _ -> Val.top_itv)
       | Const.Cfloat f -> f |> int_of_float |> Val.of_int
       | _ -> Val.bot       (* TODO *)
 


### PR DESCRIPTION
This bug-fix  handles the integer overflow issue (https://github.com/facebook/infer/issues/584) in the buffer overrun checker. 