### PR TITLE
Fix ValueError: unknown locale: UTF-8

### DIFF
--- a/infer/lib/python/inferlib/config.py
+++ b/infer/lib/python/inferlib/config.py
@@ -17,7 +17,7 @@ import os
 try:
     locale.setlocale(locale.LC_ALL, '')
     CODESET = locale.getlocale(locale.LC_CTYPE)[1]
-except locale.Error:
+except:
     CODESET = None
 if CODESET is None:
     CODESET = 'ascii'


### PR DESCRIPTION
Fix locale.getlocale throw ValueError exception, but not catch.
Related issues: #447 #445 #358 