### PR TITLE
Fix javac wrapper

### DIFF
--- a/infer/lib/wrappers/javac
+++ b/infer/lib/wrappers/javac
@@ -11,11 +11,13 @@ elif [ -z "$INFER_OLD_PATH" ]; then
 fi
 
 HOST_COMPILER=(`PATH=$INFER_OLD_PATH which javac`)
-COMPILER_ARGS="$@"
-HOST_COMPILER_COMMAND=("$HOST_COMPILER" $COMPILER_ARGS)
-FRONTEND_COMMAND=("infer" "-a" "capture" "-o" "$INFER_RESULTS_DIR" "--" "javac" $COMPILER_ARGS)
+COMPILER_ARGS=("$@")
+HOST_COMPILER_COMMAND=("$HOST_COMPILER" "${COMPILER_ARGS[@]}")
+FRONTEND_COMMAND=("infer" "-a" "capture" "-o" "$INFER_RESULTS_DIR" "--" "javac" "${COMPILER_ARGS[@]}")
 
-if [ -n "$INFER_COMPILER_WRAPPER_IN_RECURSION" ]; then
+if [[ "$*" == *-version* ]]; then
+    "${HOST_COMPILER_COMMAND[@]}"
+elif [ -n "$INFER_COMPILER_WRAPPER_IN_RECURSION" ]; then
     if [ -z "$INFER_LISTENER" ]; then
         "${HOST_COMPILER_COMMAND[@]}"
     fi


### PR DESCRIPTION
1. Allow it to forward -version calls to javac (so that if the build system wants 
    to check the compiler version it doesn't end up with Infer's version)
2. Preserve empty arguments:
    javac -bootclasspath "" -classpath a.jar ...
    currently gives:
    javac: invalid flag: a.jar