### PR TITLE
Flush output after printing bugs in txt format.

### DIFF
--- a/infer/src/backend/InferPrint.ml
+++ b/infer/src/backend/InferPrint.ml
@@ -493,7 +493,8 @@ let pp_text_of_report fmt report =
     F.fprintf fmt "%s:%d: %s: %s %s@\n" jsonbug.file jsonbug.line jsonbug.kind jsonbug.bug_type
       jsonbug.qualifier
   in
-  List.iter ~f:pp_row report
+  List.iter ~f:pp_row report;
+  F.fprintf fmt "@?"
 
 module CallsCsv = struct
   (** Write proc summary stats in csv format *)


### PR DESCRIPTION
If you run `infer report --issues-txt ilovecats.txt ...` then bugs may mysteriously miss from `ilovecats.txt`, unless you flush. (See rules of thumb for `Format` module.)