### PR TITLE
Add tty debug

### DIFF
--- a/infer/src/base/Logging.ml
+++ b/infer/src/base/Logging.ml
@@ -236,6 +236,20 @@ let debug kind level fmt =
   let to_file = compare_debug_level level base_level <= 0 in
   log ~to_console:false ~to_file debug_file_fmts fmt
 
+(* file descriptor for tty, lazily allocated *)
+let dev_tty = ref None;;
+
+let tty_debug str =
+  (match (!dev_tty) with
+  | None -> dev_tty := Some (Out_channel.create "/dev/tty")
+  | _ -> ()
+  ) ;
+  (match (!dev_tty) with
+  | (Some fh) -> Printf.fprintf fh "%s" str
+  | _ -> ()
+  )
+
+
 let result fmt = log ~to_console:true result_file_fmts fmt
 
 let environment_info fmt = log ~to_console:false environment_info_file_fmts fmt

--- a/infer/src/base/Logging.mli
+++ b/infer/src/base/Logging.mli
@@ -14,6 +14,10 @@ open! IStd
 
 module F = Format
 
+(** write a message to /dev/tty. Only intended for local
+ * debugging *)
+val tty_debug : string -> unit
+
 val environment_info : ('a, F.formatter, unit) format -> 'a
 (** log information about the environment *)
 


### PR DESCRIPTION
really simple `tty_debug` function that takes a string and writes it to the tty. Infer redirects stdout and stderr internally under some circumstances. This function is only intended to be used for `printf`-style debugging (hopefully the comment makes that clear).