### PR TITLE
Adjust Dockerfile to build 0.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,7 @@ RUN INFER_VERSION=v0.13.0; \
     ln -s ${PWD}/infer-linux64-$INFER_VERSION /infer
 
 # Compile Infer
-RUN OCAML_VERSION=4.05.0; \
-    opam init --compiler=$OCAML_VERSION -j $(nproc) --yes && \
+RUN OCAML_VERSION=4.05.0+flambda; \
     cd /infer && ./build-infer.sh --opam-switch $OCAML_VERSION && rm -rf /root/.opam
 
 # Install Infer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,22 @@
-# Base image
-FROM buildpack-deps:xenial-curl
+FROM ubuntu:17.04
 
 MAINTAINER Infer
 
-# Debian config
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
             aspcud \
-            autoconf \
-            automake \
-            gcc \
-            g++ \
-            git \
-            groff-base \
-            libc6-dev \
-            libgmp-dev \
-            libmpc-dev \
-            libmpfr-dev \
-            m4 \
-            make \
-            ncurses-dev \
-            ocaml \
+            curl \
             opam \
-            openjdk-8-jdk-headless \
             pkg-config \
-            python2.7 \
-            rsync \
-            unzip \
-            zlib1g-dev && \
+            autoconf \
+            libsqlite3-dev \
+            zlib1g-dev \
+            cmake \
+            openjdk-8-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
 # Download the latest Infer release
-RUN INFER_VERSION=v0.12.1; \
+RUN INFER_VERSION=v0.13.0; \
     cd /opt && \
     curl -sL \
       https://github.com/facebook/infer/releases/download/${INFER_VERSION}/infer-linux64-${INFER_VERSION}.tar.xz | \
@@ -40,11 +25,9 @@ RUN INFER_VERSION=v0.12.1; \
     ln -s ${PWD}/infer-linux64-$INFER_VERSION /infer
 
 # Compile Infer
-RUN OCAML_VERSION=4.04.2; \
-    opam init --compiler=$OCAML_VERSION -j $(getconf _NPROCESSORS_ONLN || echo 1) --yes && \
-    cd /infer && \
-    ./build-infer.sh --opam-switch $OCAML_VERSION && \
-    rm -rf /root/.opam
+RUN OCAML_VERSION=4.05.0; \
+    opam init --compiler=$OCAML_VERSION -j $(nproc) --yes && \
+    cd /infer && ./build-infer.sh --opam-switch $OCAML_VERSION && rm -rf /root/.opam
 
 # Install Infer
 ENV INFER_HOME /infer/infer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && \
             libsqlite3-dev \
             zlib1g-dev \
             cmake \
+            libc6-dev \
+            libc6-i386 \
+            lib32z1 \
+            lib32stdc++6 \
             openjdk-8-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
@@ -32,15 +36,6 @@ RUN OCAML_VERSION=4.05.0; \
 # Install Infer
 ENV INFER_HOME /infer/infer
 ENV PATH ${INFER_HOME}/bin:${PATH}
-
-# Install dependencies for Android sample
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-            libc6-dev \
-            libc6-i386 \
-            lib32z1 \
-            lib32stdc++6 && \
-    rm -rf /var/lib/apt/lists/*
 
 ENV ANDROID_HOME /opt/android-sdk-linux
 WORKDIR $ANDROID_HOME


### PR DESCRIPTION
I was unable to build 0.13 with the current Dockerfile. Changing the Infer version to 0.13 resulted in errors about the ocaml version not being >= 4.05 and < 4.06. When changing the ocaml version I found that the sqlite extension wouldn't compile via opam.

I tried to clean this up a little bit as I went but please let me know if I have reduced it too much. I made sure that everything still worked by running following the Docker steps outlined here http://fbinfer.com/docs/getting-started.html

Here's some info about the bits in the finalized container:

```
infer --version
Infer version v0.13.0
Copyright 2009 - present Facebook. All Rights Reserved.
```

```
opam --version
1.2.2
```

```
ocaml -version
The OCaml toplevel, version 4.02.3
```

```
java -version
openjdk version "1.8.0_131"
OpenJDK Runtime Environment (build 1.8.0_131-8u131-b11-2ubuntu1.17.04.3-b11)
OpenJDK 64-Bit Server VM (build 25.131-b11, mixed mode)
```