### PR TITLE
Correct typos for most of section 1 docs

### DIFF
--- a/_docs/01-advanced-features.md
+++ b/_docs/01-advanced-features.md
@@ -52,7 +52,7 @@ In each captured folder, we obtain the file `icfg.dot`, which is the graphical r
 `call_graph.dot`, that is the graphical representation of the call graph.
 
 
-Moreover, we obtain an html page for each captured file inside `infer-out/captured`. This html file contains the source file. In each line of the file there are links to the nodes of the control flow graph that correspond to that line of code. So one can see what the translation looks like. Moreover, when you click on those links you can see details of the symbolic execution of that particular node. If the option `--no_test` is also passed to `infer`, then the page pointed to from the nodes contains the printout of the whole symbolic execution.
+Moreover, we obtain an HTML page for each captured file inside `infer-out/captured`. This HTML file contains the source file. In each line of the file there are links to the nodes of the control flow graph that correspond to that line of code. So one can see what the translation looks like. Moreover, when you click on those links you can see details of the symbolic execution of that particular node. If the option `--no_test` is also passed to `infer`, then the page pointed to from the nodes contains the printout of the whole symbolic execution.
 
 ## Print the specs
 

--- a/_docs/01-checkers.md
+++ b/_docs/01-checkers.md
@@ -11,7 +11,7 @@ Infer.AI is a collection of program analyses which range from simple checks to s
 Infer.AI is so named because it is based on Abstract Interpretation. 
 
 Current Infer.AI's which are in production include ThreadSafety, 
-AnnotationReachability (e.g., can an allocation be reachef from a @PerformanceCritical method), and [immutable cast](docs/checkers-bug-types.html#CHECKERS_IMMUTABLE_CAST) for Java, as well as Static Initialization Order Fiasco for C++. 
+AnnotationReachability (e.g., can an allocation be reached from a @PerformanceCritical method), and [immutable cast](docs/checkers-bug-types.html#CHECKERS_IMMUTABLE_CAST) for Java, as well as Static Initialization Order Fiasco for C++. 
 
 The current checkers can be run by adding the option `-a checkers` to the analysis command as in this example:
 
@@ -20,7 +20,7 @@ infer run -a checkers -- javac Test.java
 ```
 
 In addition, we are working on experimental AI's which target 
-security properties (Quandary) and buffer overrusn (Inferbo). The infer commandline man page
-(`infer --help`) tells how to run experimental AI's, or to select certain AI's and not others.
+security properties (Quandary) and buffer overruns (Inferbo). The infer commandline man page
+(`infer --help`) explains how to run experimental AI's, or how to select certain AI's and not others.
 
  

--- a/_docs/01-linters.md
+++ b/_docs/01-linters.md
@@ -50,7 +50,7 @@ Once the new linter is added to the linters' file it will then work out of the b
 
 <a name="clang_ast">**Getting the clang AST**</a>  
 
-When you write a linter that traverses the AST of some programs to check some property, you probably need to understand how the AST looks like. You can get the AST of programs using clang directly, or using Infer. 
+When you write a linter that traverses the AST of some programs to check some property, you probably need to understand what the AST looks like. You can get the AST of programs using clang directly, or using Infer. 
 
 If you have a clang command `clang <clang arguments> File.m` then you can get the AST with 
 
@@ -331,7 +331,7 @@ DEFINE-CHECKER ASSIGN_POINTER_WARNING = {
   };
 ```
 
-The checker uses two predefined predicates `is_assign_property()` and `is_property_pointer_type()` which are true if the property being declared is assign and has a pointer type respectively. We want to check both condition only on nodes declaring properties, i.e., `ObjCPropertyDecl`.
+The checker uses two predefined predicates `is_assign_property()` and `is_property_pointer_type()` which are true if the property being declared is assign and has a pointer type respectively. We want to check both conditions only on nodes declaring properties, i.e., `ObjCPropertyDecl`.
 
 <hr>
 
@@ -527,11 +527,11 @@ DEFINE-CHECKER ENUM_CONSTANTS = {
 
 <a name="info_message">**AST info in messages**</a>
 
-When you write the message of your rule, you may want to specify which particular ast items were involved in the issue, such as a type or a variable name. We have a mechanism for that, we specified a few placeholders that can be used in rules with the syntax `%placeholder%` and it will be substituted by the correct ast info. At the moment we have `%type%`, `%child_type%` and `%name%` that print the type of the node, the type of the node's child, and a string representation of the node, respectively. As with predicates, we can add more as needed.
+When you write the message of your rule, you may want to specify which particular AST items were involved in the issue, such as a type or a variable name. We have a mechanism for that, we specified a few placeholders that can be used in rules with the syntax `%placeholder%` and it will be substituted by the correct AST info. At the moment we have `%type%`, `%child_type%` and `%name%` that print the type of the node, the type of the node's child, and a string representation of the node, respectively. As with predicates, we can add more as needed.
 
 <a name="testing">**Testing your rule**</a>
 
-To test your rule you need to run it with Infer. If you are adding a new linter you can test it in a separate al file that you can pass to Infer with the option `--linters-def-file file.al`. Pass the option `--linters-developer-mode` to Infer that will print debug information and only take the linters from that file into account in the execution, it will ignore the default linters, so it will be faster and debug info will be only 
+To test your rule you need to run it with Infer. If you are adding a new linter you can test it in a separate al file that you can pass to Infer with the option `--linters-def-file file.al`. Pass the option `--linters-developer-mode` to Infer to print debug information and only take the linters from that file into account in the execution, it will ignore the default linters, so it will be faster and the debug info will be only 
 about your linter.
 
 To test your code, write a small example that triggers the rule. Then, run your code with
@@ -559,7 +559,7 @@ Moreover, the bug can be found in the file `infer-out/report.json` where `infer-
 
 <a name="debugging">**Debugging**</a>
 
-If there are syntax errors or other parsing errors with your al file, you will get an error message when testing the rule, remember to use `linters-developer-mode` when you are developing a rule. If the rule gets parsed but still doesn't behave as you expect, you can debug it, by adding the following line to a test source file in the line where you want to debug the rule: `//INFER_BREAKPOINT`. Then run infer again in linters developer mode, and it will stop the execution of the linter in the line of the breakpoint. Then you can follow the execution step by step. It shows the current formula that is being evaluated, and the current part of the AST that is being checked. A red node means that the formula failed, a green node means that it succeeded.
+If there are syntax errors or other parsing errors with your al file, you will get an error message when testing the rule, remember to use `linters-developer-mode` when you are developing a rule. If the rule gets parsed but still doesn't behave as you expect, you can debug it, by adding the following line to a test source file in the line where you want to debug the rule: `//INFER_BREAKPOINT`. Then run infer again in linters developer mode, and it will stop the execution of the linter on the line of the breakpoint. Then you can follow the execution step by step. It shows the current formula that is being evaluated, and the current part of the AST that is being checked. A red node means that the formula failed, a green node means that it succeeded.
 
 <a name="demo">**Demo**</a>
 

--- a/_docs/01-steps-for-ci.md
+++ b/_docs/01-steps-for-ci.md
@@ -5,7 +5,7 @@ layout: docs
 permalink: /docs/steps-for-ci.html
 ---
 
-The recommended flow for CI integration is to determine the modified files, and run the analysis in reactive mode starting from those files. If you would like to run more then one analyzer, it is more efficient to separate the capture phase, so that the result can be used by all the analyzers.
+The recommended flow for CI integration is to determine the modified files, and run the analysis in reactive mode starting from those files. If you would like to run more than one analyzer, it is more efficient to separate the capture phase, so that the result can be used by all the analyzers.
 
 ### Differential Workflow
 

--- a/_docs/02-about-infer.md
+++ b/_docs/02-about-infer.md
@@ -15,7 +15,7 @@ Infer came to Facebook with the acquisition of the verification startup Monoidic
 Monoidics was itself based on recent academic research, particularly on separation logic and bi-abduction.
 
 We have broadened Infer's scope within the past few years. We now refer to the original separation logic analysis as 
-Infer.SL.We now also have    Infer.AI. a general analysis framework which is     an interface to the modular analysis engine which can be used by other kinds of program analyses (technically, called ``abstract interpretations'', hence the AI monicker).  
+Infer.SL. We now also have    Infer.AI, a general analysis framework which is     an interface to the modular analysis engine which can be used by other kinds of program analyses (technically, called ''abstract interpretations'', hence the AI monicker).  
 This added generality has been used to develop instantiations of Infer.AI for security, concurrency and in other domains.
 Additionally, we have Infer linters for describing shallow syntactic analyses, using the AL language,
 because sometimes linters are just what you need.


### PR DESCRIPTION
I saw "then" in place of "than" and just couldn't keep reading without fixing it.