### PR TITLE
Use SQLite in a way that is compatible with current state of WSL

### DIFF
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1874,6 +1874,19 @@ and specs_library =
   specs_library
 
 
+and sqlite_vfs =
+  let default =
+    match Utils.read_file "/proc/version" with
+    | Result.Ok [line] ->
+        let re = Str.regexp "Linux.+-Microsoft" in
+        (* on WSL (bash on Windows) standard SQLite VFS can't be used, see WSL/issues/1927 WSL/issues/2395 *)
+        if Str.string_match re line 0 then Some "unix-excl" else None
+    | _ ->
+        None
+  in
+  CLOpt.mk_string_opt ?default ~long:"sqlite-vfs" "VFS for SQLite"
+
+
 and stacktrace =
   CLOpt.mk_path_opt ~deprecated:["st"] ~long:"stacktrace"
     ~in_help:CLOpt.([(Analyze, manual_crashcontext)])
@@ -2658,6 +2671,8 @@ and sources = !sources
 and sourcepath = !sourcepath
 
 and spec_abs_level = !spec_abs_level
+
+and sqlite_vfs = !sqlite_vfs
 
 and stacktrace = !stacktrace
 

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -645,6 +645,8 @@ val spec_abs_level : int
 
 val specs_library : string list
 
+val sqlite_vfs : string option
+
 val stacktrace : string option
 
 val stacktraces_dir : string option

--- a/infer/src/base/ResultsDatabase.ml
+++ b/infer/src/base/ResultsDatabase.ml
@@ -36,8 +36,13 @@ let create_db () =
   create_attributes_table db ;
   (* This should be the default but better be sure, otherwise we cannot access the database concurrently. This has to happen before setting WAL mode. *)
   SqliteUtils.exec db ~log:"locking mode=NORMAL" ~stmt:"PRAGMA locking_mode=NORMAL" ;
-  (* Write-ahead log is much faster than other journalling modes. *)
-  SqliteUtils.exec db ~log:"journal_mode=WAL" ~stmt:"PRAGMA journal_mode=WAL" ;
+  ( match Config.sqlite_vfs with
+  | None ->
+      (* Write-ahead log is much faster than other journalling modes. *)
+      SqliteUtils.exec db ~log:"journal_mode=WAL" ~stmt:"PRAGMA journal_mode=WAL"
+  | Some _ ->
+      (* Can't use WAL with custom VFS *)
+      () ) ;
   SqliteUtils.db_close db ;
   try Sys.rename temp_db database_fullpath
   with Sys_error _ -> (* lost the race, doesn't matter *) ()
@@ -104,7 +109,10 @@ let db_close () =
 
 let new_database_connection () =
   db_close () ;
-  let db = Sqlite3.db_open ~mode:`NO_CREATE ~cache:`PRIVATE ~mutex:`FULL database_fullpath in
+  let db =
+    Sqlite3.db_open ~mode:`NO_CREATE ~cache:`PRIVATE ~mutex:`FULL ?vfs:Config.sqlite_vfs
+      database_fullpath
+  in
   Sqlite3.busy_timeout db 10_000 ;
   (* Higher level of "synchronous" are only useful to guarantee that the db will not be corrupted if the machine crashes for some reason before the data has been actually written to disk. We do not need this kind of guarantee for infer results as one can always rerun infer if interrupted. *)
   SqliteUtils.exec db ~log:"synchronous=OFF" ~stmt:"PRAGMA synchronous=OFF" ;


### PR DESCRIPTION
To resole #797  this adds runtime option to select VFS for SQLite, 

When infer runs on WSL this defaults to "unix-excl" (https://sqlite.org/vfs.html) and if VFS is specified, then   WAL  is not enabled (since WAL is non compatible with custom VFS  - https://www.sqlite.org/wal.html).
