### PR TITLE
Don't join postconditions. Fixes #678.

### DIFF
--- a/infer/src/backend/interproc.ml
+++ b/infer/src/backend/interproc.ml
@@ -762,7 +762,7 @@ let collect_postconditions wl tenv proc_cfg : Paths.PathSet.t * Specs.Visitedset
         vset_ref_add_pathset vset_ref pathset_diverging ;
         compute_visited !vset_ref
       in
-      (do_join_post pname tenv pathset, visited)
+      (pathset, visited)
     with Exceptions.Leak _ ->
       L.d_strln "Leak in post collection" ;
       assert false


### PR DESCRIPTION
Increases precision a bit. I didn't observe speed problems on what I tested. (But, who knows?)