### PR TITLE
[C/C++] Encode filename into the Procname of global initializers

### DIFF
--- a/infer/src/IR/Pvar.ml
+++ b/infer/src/IR/Pvar.ml
@@ -277,8 +277,6 @@ let get_initializer_pname {pv_name; pv_kind} =
   match pv_kind with
   | Global_var (translation, _, _, _, is_static_global) ->
       let name = Config.clang_initializer_prefix ^ Mangled.to_string_full pv_name in
-      if is_static_global then print_endline ("Static : " ^ name) ;
-      (* let is_static_global = false in *)
       if is_static_global then
         match translation with
         | TUFile file ->

--- a/infer/src/IR/Pvar.ml
+++ b/infer/src/IR/Pvar.ml
@@ -24,9 +24,9 @@ type pvar_kind =
       (** synthetic variable to represent return value *)
   | Abduced_ref_param of Typ.Procname.t * int * Location.t
       (** synthetic variable to represent param passed by reference *)
-  | Global_var of (translation_unit * bool * bool * bool)
+  | Global_var of (translation_unit * bool * bool * bool * bool)
       (** global variable: translation unit + is it compile constant? + is it POD? + is it a static
-      local? *)
+      local?  + is it a static global *)
   | Seed_var  (** variable used to store the initial value of formal parameters *)
   [@@deriving compare]
 
@@ -77,7 +77,7 @@ let _pp f pv =
   | Abduced_ref_param (n, index, l) ->
       if !Config.pp_simple then F.fprintf f "%a|abducedRefParam%d" Mangled.pp name index
       else F.fprintf f "%a$[%a]%a|abducedRefParam" Typ.Procname.pp n Location.pp l Mangled.pp name
-  | Global_var (translation_unit, is_const, is_pod, _) ->
+  | Global_var (translation_unit, is_const, is_pod, _, _) ->
       F.fprintf f "#GB<%a%s%s>$%a" pp_translation_unit translation_unit
         (if is_const then "|const" else "")
         (if not is_pod then "|!pod" else "")
@@ -161,7 +161,7 @@ let is_seed pv = match pv.pv_kind with Seed_var -> true | _ -> false
 (** Check if the pvar is a global var *)
 let is_global pv = match pv.pv_kind with Global_var _ -> true | _ -> false
 
-let is_static_local pv = match pv.pv_kind with Global_var (_, _, _, true) -> true | _ -> false
+let is_static_local pv = match pv.pv_kind with Global_var (_, _, _, true, _) -> true | _ -> false
 
 (** Check if a pvar is the special "this" var *)
 let is_this pvar = Mangled.equal (get_name pvar) (Mangled.from_string "this")
@@ -233,11 +233,12 @@ let mk_callee (name: Mangled.t) (proc_name: Typ.Procname.t) : t =
 
 
 (** create a global variable with the given name *)
-let mk_global ?(is_constexpr= false) ?(is_pod= true) ?(is_static_local= false) (name: Mangled.t)
-    translation_unit : t =
+let mk_global ?(is_constexpr= false) ?(is_pod= true) ?(is_static_local= false)
+    ?(is_static_global= false) (name: Mangled.t) translation_unit : t =
   { pv_hash= name_hash name
   ; pv_name= name
-  ; pv_kind= Global_var (translation_unit, is_constexpr, is_pod, is_static_local) }
+  ; pv_kind= Global_var (translation_unit, is_constexpr, is_pod, is_static_local, is_static_global)
+  }
 
 
 (** create a fresh temporary variable local to procedure [pname]. for use in the frontends only! *)
@@ -260,22 +261,36 @@ let mk_abduced_ref_param (proc_name: Typ.Procname.t) (index: int) (loc: Location
 
 let get_translation_unit pvar =
   match pvar.pv_kind with
-  | Global_var (tu, _, _, _) ->
+  | Global_var (tu, _, _, _, _) ->
       tu
   | _ ->
       L.(die InternalError) "Expected a global variable"
 
 
-let is_compile_constant pvar = match pvar.pv_kind with Global_var (_, b, _, _) -> b | _ -> false
+let is_compile_constant pvar =
+  match pvar.pv_kind with Global_var (_, b, _, _, _) -> b | _ -> false
 
-let is_pod pvar = match pvar.pv_kind with Global_var (_, _, b, _) -> b | _ -> true
+
+let is_pod pvar = match pvar.pv_kind with Global_var (_, _, b, _, _) -> b | _ -> true
 
 let get_initializer_pname {pv_name; pv_kind} =
   match pv_kind with
-  | Global_var _ ->
-      Some
-        (Typ.Procname.from_string_c_fun
-           (Config.clang_initializer_prefix ^ Mangled.to_string_full pv_name))
+  | Global_var (translation, _, _, _, is_static_global) ->
+      let name = Config.clang_initializer_prefix ^ Mangled.to_string_full pv_name in
+      if is_static_global then print_endline ("Static : " ^ name) ;
+      (* let is_static_global = false in *)
+      if is_static_global then
+        match translation with
+        | TUFile file ->
+            let mangled = SourceFile.to_string file |> Utils.string_crc_hex32 in
+            Typ.Procname.C
+              (Typ.Procname.c
+                 (QualifiedCppName.of_qual_string name)
+                 mangled Typ.NoTemplate ~is_generic_model:false)
+            |> Option.return
+        | TUExtern ->
+            None
+      else Some (Typ.Procname.from_string_c_fun name)
   | _ ->
       None
 

--- a/infer/src/IR/Pvar.mli
+++ b/infer/src/IR/Pvar.mli
@@ -92,7 +92,8 @@ val mk_callee : Mangled.t -> Typ.Procname.t -> t
     for a callee function with the given function name *)
 
 val mk_global :
-  ?is_constexpr:bool -> ?is_pod:bool -> ?is_static_local:bool -> Mangled.t -> translation_unit -> t
+  ?is_constexpr:bool -> ?is_pod:bool -> ?is_static_local:bool -> ?is_static_global:bool
+  -> Mangled.t -> translation_unit -> t
 (** create a global variable with the given name *)
 
 val mk_tmp : string -> Typ.Procname.t -> t

--- a/infer/src/clang/cGeneral_utils.ml
+++ b/infer/src/clang/cGeneral_utils.ml
@@ -154,8 +154,14 @@ let mk_sil_global_var {CFrontend_config.source_file} ?(mk_name= fun _ x -> x) na
          | _ ->
              true )
   in
+  let is_static_global =
+    var_decl_info.Clang_ast_t.vdi_is_global
+    (* only top level declarations are really have file scope, static field members have a global scope *)
+    && not var_decl_info.Clang_ast_t.vdi_is_static_data_member
+    && match var_decl_info.Clang_ast_t.vdi_storage_class with Some "static" -> true | _ -> false
+  in
   Pvar.mk_global ~is_constexpr ~is_pod
-    ~is_static_local:var_decl_info.Clang_ast_t.vdi_is_static_local
+    ~is_static_local:var_decl_info.Clang_ast_t.vdi_is_static_local ~is_static_global
     (mk_name name_string simple_name) translation_unit
 
 

--- a/infer/tests/codetoanalyze/cpp/frontend/globals/global_const1.cpp.dot
+++ b/infer/tests/codetoanalyze/cpp/frontend/globals/global_const1.cpp.dot
@@ -11,17 +11,17 @@ digraph iCFG {
 	
 
 	 "__infer_globals_initializer_global.bdc08c089842ce08b974b22a75daf78e_3" -> "__infer_globals_initializer_global.bdc08c089842ce08b974b22a75daf78e_2" ;
-"__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_1" [label="1: Start __infer_globals_initializer_v\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 17, column 1]\n " color=yellow style=filled]
+"__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_1" [label="1: Start __infer_globals_initializer_v\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 17, column 1]\n " color=yellow style=filled]
 	
 
-	 "__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_1" -> "__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_3" ;
-"__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_2" [label="2: Exit __infer_globals_initializer_v \n  " color=yellow style=filled]
+	 "__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_1" -> "__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_3" ;
+"__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_2" [label="2: Exit __infer_globals_initializer_v \n  " color=yellow style=filled]
 	
 
-"__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_3" [label="3:  DeclStmt \n   *&#GB<codetoanalyze/cpp/frontend/globals/global_const1.cpp>$v:int=2 [line 17, column 1]\n " shape="box"]
+"__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_3" [label="3:  DeclStmt \n   *&#GB<codetoanalyze/cpp/frontend/globals/global_const1.cpp>$v:int=2 [line 17, column 1]\n " shape="box"]
 	
 
-	 "__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_3" -> "__infer_globals_initializer_v.4e4b88201c5f529e31ed314500b0b0e5_2" ;
+	 "__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_3" -> "__infer_globals_initializer_v#708fabe5dc8ff523caaa5f44184921e8.588095fa475e4a9e8c83f50f26a48ea9_2" ;
 "test2#3587805488049044947.69e45cfdc4e36a6f741ce3985858724b_1" [label="1: Start test2\nFormals: \nLocals:  local:int \n   DECLARE_LOCALS(&return,&local); [line 19, column 1]\n " color=yellow style=filled]
 	
 

--- a/infer/tests/codetoanalyze/cpp/frontend/globals/initializer.cpp.dot
+++ b/infer/tests/codetoanalyze/cpp/frontend/globals/initializer.cpp.dot
@@ -1,25 +1,25 @@
 /* @generated */
 digraph iCFG {
-"__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_1" [label="1: Start __infer_globals_initializer_x\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 14, column 1]\n " color=yellow style=filled]
+"__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_1" [label="1: Start __infer_globals_initializer_x\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 14, column 1]\n " color=yellow style=filled]
 	
 
-	 "__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_1" -> "__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_3" ;
-"__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_2" [label="2: Exit __infer_globals_initializer_x \n  " color=yellow style=filled]
+	 "__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_1" -> "__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_3" ;
+"__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_2" [label="2: Exit __infer_globals_initializer_x \n  " color=yellow style=filled]
 	
 
-"__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_3" [label="3:  DeclStmt \n   n$0=_fun_foo() [line 14, column 16]\n  *&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$x:int=(n$0 + 5) [line 14, column 1]\n " shape="box"]
+"__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_3" [label="3:  DeclStmt \n   n$0=_fun_foo() [line 14, column 16]\n  *&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$x:int=(n$0 + 5) [line 14, column 1]\n " shape="box"]
 	
 
-	 "__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_3" -> "__infer_globals_initializer_x.90ed5779794b6c6f0b00544949bb1047_2" ;
-"__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_1" [label="1: Start __infer_globals_initializer_y\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 15, column 1]\n " color=yellow style=filled]
+	 "__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_3" -> "__infer_globals_initializer_x#346c89dda90b0be6289346ddbf0528bc.83245b9f254e67fb6f879cc1e35a1bb1_2" ;
+"__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_1" [label="1: Start __infer_globals_initializer_y\nFormals: \nLocals:  \n   DECLARE_LOCALS(&return); [line 15, column 1]\n " color=yellow style=filled]
 	
 
-	 "__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_1" -> "__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_3" ;
-"__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_2" [label="2: Exit __infer_globals_initializer_y \n  " color=yellow style=filled]
+	 "__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_1" -> "__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_3" ;
+"__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_2" [label="2: Exit __infer_globals_initializer_y \n  " color=yellow style=filled]
 	
 
-"__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_3" [label="3:  DeclStmt \n   n$0=*&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$x:int [line 15, column 16]\n  n$1=*&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$z:int [line 15, column 20]\n  *&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$y:int=((n$0 + n$1) + 1) [line 15, column 1]\n " shape="box"]
+"__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_3" [label="3:  DeclStmt \n   n$0=*&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$x:int [line 15, column 16]\n  n$1=*&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$z:int [line 15, column 20]\n  *&#GB<codetoanalyze/cpp/frontend/globals/initializer.cpp>$y:int=((n$0 + n$1) + 1) [line 15, column 1]\n " shape="box"]
 	
 
-	 "__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_3" -> "__infer_globals_initializer_y.0ea250be2dd991733c9131c53abc3c54_2" ;
+	 "__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_3" -> "__infer_globals_initializer_y#346c89dda90b0be6289346ddbf0528bc.e7d659d11156f551397be6d5db27f31c_2" ;
 }


### PR DESCRIPTION
This resolves #796 . Effectively it adds file specific suffix to name of all global initializers (so initializersof two global variable of the same name will have unique Typ.Procname). which is the same rule as currently used by constructing Procname for the static functions.  However this change applies to initializers of all global variables and not just static (arguably it's a right thing. since GCC used to allow multiple global variables with the same name).

Consequences of this change that it becomes impossible to know name of generated initialization function of global ('extern') variables. However get_initializer_pname function is only referenced by the frontend (when creating initializer for the defined global  variables) and by the SIOF checker.
