### PR TITLE
Fixed namespace for Java globals.

### DIFF
--- a/infer/src/IR/Pvar.ml
+++ b/infer/src/IR/Pvar.ml
@@ -16,7 +16,6 @@ module F = Format
 
 type translation_unit =
   | TUAnonymous
-  | TUExtern
   | TUFile of SourceFile.t
   [@@deriving compare]
 
@@ -61,9 +60,7 @@ let equal = [%compare.equal : t]
 
 let pp_translation_unit fmt = function
   | TUAnonymous ->
-      ()
-  | TUExtern ->
-      Format.fprintf fmt "EXTERN"
+      Format.fprintf fmt "ANONYMOUS"
   | TUFile fname ->
       SourceFile.pp fmt fname
 
@@ -268,7 +265,7 @@ let get_initializer_pname {pv_name; pv_kind} =
                  (QualifiedCppName.of_qual_string name)
                  mangled Typ.NoTemplate ~is_generic_model:false)
             |> Option.return
-        | TUAnonymous | TUExtern ->
+        | TUAnonymous ->
             None
       else Some (Typ.Procname.from_string_c_fun name)
   | _ ->

--- a/infer/src/IR/Pvar.mli
+++ b/infer/src/IR/Pvar.mli
@@ -15,7 +15,6 @@ module F = Format
 
 type translation_unit =
   | TUAnonymous
-  | TUExtern
   | TUFile of SourceFile.t
   [@@deriving compare]
 

--- a/infer/src/IR/Pvar.mli
+++ b/infer/src/IR/Pvar.mli
@@ -13,7 +13,11 @@
 open! IStd
 module F = Format
 
-type translation_unit = TUFile of SourceFile.t | TUExtern [@@deriving compare]
+type translation_unit =
+  | TUAnonymous
+  | TUExtern
+  | TUFile of SourceFile.t
+  [@@deriving compare]
 
 (** Type for program variables. There are 4 kinds of variables:
         1) local variables, used for local variables and formal parameters
@@ -93,7 +97,7 @@ val mk_callee : Mangled.t -> Typ.Procname.t -> t
 
 val mk_global :
   ?is_constexpr:bool -> ?is_pod:bool -> ?is_static_local:bool -> ?is_static_global:bool
-  -> Mangled.t -> translation_unit -> t
+  -> ?translation_unit:translation_unit -> Mangled.t -> t
 (** create a global variable with the given name *)
 
 val mk_tmp : string -> Typ.Procname.t -> t

--- a/infer/src/IR/Sil.ml
+++ b/infer/src/IR/Sil.ml
@@ -2035,4 +2035,4 @@ let hpara_dll_instantiate (para: hpara_dll) cell blink flink elist =
   (ids_evars, List.map ~f:(hpred_sub subst) para.body_dll)
 
 
-let custom_error = Pvar.mk_global ~translation_unit:Pvar.TUExtern (Mangled.from_string "INFER_CUSTOM_ERROR")
+let custom_error = Pvar.mk_global ~translation_unit:Pvar.TUAnonymous (Mangled.from_string "INFER_CUSTOM_ERROR")

--- a/infer/src/IR/Sil.ml
+++ b/infer/src/IR/Sil.ml
@@ -2035,4 +2035,4 @@ let hpara_dll_instantiate (para: hpara_dll) cell blink flink elist =
   (ids_evars, List.map ~f:(hpred_sub subst) para.body_dll)
 
 
-let custom_error = Pvar.mk_global (Mangled.from_string "INFER_CUSTOM_ERROR") Pvar.TUExtern
+let custom_error = Pvar.mk_global ~translation_unit:Pvar.TUExtern (Mangled.from_string "INFER_CUSTOM_ERROR")

--- a/infer/src/checkers/Siof.ml
+++ b/infer/src/checkers/Siof.ml
@@ -181,10 +181,8 @@ let is_foreign tu_opt v =
   match (Pvar.get_translation_unit v, tu_opt) with
   | TUFile v_tu, Some current_tu ->
       not (SourceFile.equal current_tu v_tu)
-  | TUExtern, Some _ ->
+  | TUAnonymous, Some _ ->
       true
-  | TUAnonymous, _ ->
-      L.(die InternalError) "for C/++, translation units should be known"
   | _, None ->
       L.(die InternalError) "cannot be called with translation unit set to None"
 

--- a/infer/src/checkers/Siof.ml
+++ b/infer/src/checkers/Siof.ml
@@ -183,6 +183,8 @@ let is_foreign tu_opt v =
       not (SourceFile.equal current_tu v_tu)
   | TUExtern, Some _ ->
       true
+  | TUAnonymous, _ ->
+      L.(die InternalError) "for C/++, translation units should be known"
   | _, None ->
       L.(die InternalError) "cannot be called with translation unit set to None"
 
@@ -246,10 +248,10 @@ let checker {Callbacks.proc_desc; tenv; summary; get_procs_in_file} : Specs.summ
         (* always [Some _] because we create a global variable with [mk_global] *)
         Option.value_exn
           ( Pvar.mk_global
+              ~translation_unit:(TUFile tu)
               (Mangled.from_string
                  (* infer's C++ headers define this global variable in <iostream> *)
                  "__infer_translation_unit_init_streams")
-              (TUFile tu)
           |> Pvar.get_initializer_pname )
       in
       get_procs_in_file pname |> List.exists ~f:(Typ.Procname.equal magic_iostream_marker)

--- a/infer/src/clang/cGeneral_utils.ml
+++ b/infer/src/clang/cGeneral_utils.ml
@@ -162,7 +162,7 @@ let mk_sil_global_var {CFrontend_config.source_file} ?(mk_name= fun _ x -> x) na
   in
   Pvar.mk_global ~is_constexpr ~is_pod
     ~is_static_local:var_decl_info.Clang_ast_t.vdi_is_static_local ~is_static_global
-    (mk_name name_string simple_name) translation_unit
+    ~translation_unit (mk_name name_string simple_name)
 
 
 let mk_sil_var trans_unit_ctx named_decl_info decl_info_qual_type_opt procname outer_procname =

--- a/infer/src/clang/cGeneral_utils.ml
+++ b/infer/src/clang/cGeneral_utils.ml
@@ -130,10 +130,10 @@ let mk_sil_global_var {CFrontend_config.source_file} ?(mk_name= fun _ x -> x) na
   let translation_unit =
     match Clang_ast_t.(var_decl_info.vdi_is_extern, var_decl_info.vdi_init_expr) with
     | true, None ->
-        Pvar.TUExtern
+        Pvar.TUAnonymous
     | _, None when var_decl_info.Clang_ast_t.vdi_is_static_data_member ->
         (* non-const static data member get extern scope unless they are defined out of line here (in which case vdi_init_expr will not be None) *)
-        Pvar.TUExtern
+        Pvar.TUAnonymous
     | true, Some _
     (* "extern" variables with initialisation code are not extern at all, but compilers accept this *)
     | false, _ ->

--- a/infer/src/java/jTrans.ml
+++ b/infer/src/java/jTrans.ml
@@ -437,7 +437,6 @@ let create_sil_deref exp typ loc =
 let rec expression (context: JContext.t) pc expr =
   let program = context.program in
   let loc = get_location context.source_file context.impl pc in
-  let file = loc.Location.file in
   let tenv = JContext.get_tenv context in
   let type_of_expr = JTransType.expr_type context expr in
   let trans_var pvar =
@@ -538,7 +537,7 @@ let rec expression (context: JContext.t) pc expr =
   | JBir.StaticField (cn, fs) ->
       let class_exp =
         let classname = Mangled.from_string (JBasics.cn_name cn) in
-        let var_name = Pvar.mk_global classname (Pvar.TUFile file) in
+        let var_name = Pvar.mk_global classname in
         Exp.Lvar var_name
       in
       let instrs, sil_expr = ([], class_exp) in
@@ -760,7 +759,6 @@ let instruction (context: JContext.t) pc instr : translation =
   let ret_var = Pvar.get_ret_pvar proc_name in
   let ret_type = Procdesc.get_ret_type context.procdesc in
   let loc = get_location context.source_file context.impl pc in
-  let file = loc.Location.file in
   let match_never_null = Inferconfig.never_return_null_matcher in
   let create_node node_kind sil_instrs =
     Procdesc.create_node context.procdesc loc node_kind sil_instrs
@@ -830,7 +828,7 @@ let instruction (context: JContext.t) pc instr : translation =
     | JBir.AffectStaticField (cn, fs, e_rhs) ->
         let class_exp =
           let classname = Mangled.from_string (JBasics.cn_name cn) in
-          let var_name = Pvar.mk_global classname (Pvar.TUFile file) in
+          let var_name = Pvar.mk_global classname in
           Exp.Lvar var_name
         in
         let stml1, sil_expr_lhs = ([], class_exp) in


### PR DESCRIPTION
In Java, static variables are distinguished by package/class:
the file where they are defined doesn't matter.

Fixes #831.