### PR TITLE
eradicate-warnings docs: Fix source samples

### DIFF
--- a/_docs/03-eradicate-warnings.md
+++ b/_docs/03-eradicate-warnings.md
@@ -248,7 +248,7 @@ Action: choose a consistent annotation based on the desired invariant.
 
 Example:
 
-````java
+```java
 class A {
 
   int len(@Nullable String s) {
@@ -270,7 +270,7 @@ class B extends A {
 
 A consistent use of @Nullable on parameters across subtyping should prevent runtime issue like in:
 
-````java
+```java
 public class Main {
 
   String s;


### PR DESCRIPTION
There were some superfluous backticks that broke the rendering.

http://fbinfer.com/docs/eradicate-warnings.html

![screenshot from 2018-01-25 12-12-53](https://user-images.githubusercontent.com/9906/35387800-1e50c224-01c9-11e8-84fd-b55530e51e1a.png)
