### PR TITLE
Fix getcwd model to allow NULL argument

### DIFF
--- a/infer/models/c/src/libc_basic.c
+++ b/infer/models/c/src/libc_basic.c
@@ -643,15 +643,27 @@ int fputc(int c, FILE* stream) {
 char* getcwd(char* buffer, size_t size) {
   int n;
   int size_buf;
-  n = __infer_nondet_int();
+  char *result;
 
-  if (n > 0) {
-    __require_allocated_array(buffer);
-    size_buf = __get_array_length(buffer);
-    INFER_EXCLUDE_CONDITION(size > size_buf);
-    return buffer;
-  } else
-    return NULL;
+  if (NULL == buffer) {
+    n = __infer_nondet_int();
+
+    if (n > 0) {
+      __require_allocated_array(buffer);
+      size_buf = __get_array_length(buffer);
+      INFER_EXCLUDE_CONDITION(size > size_buf);
+      result = buffer;
+    } else
+        result = NULL;
+  } else {
+      if (size == 0) {
+          n = __infer_nondet_int();
+      } else {
+          n = size;
+      }
+      result = malloc(n);
+  }
+  return result;
 }
 
 // return nonteterministically 0 or -1


### PR DESCRIPTION
The model for `getcwd` assumes the first argument should be non-null when in fact a NULL pointer is legitimate and results in allocation:

>       As  an  extension to the POSIX.1-2001 standard, glibc's getcwd() allocates the buffer dynamically using mal‐
>       loc(3) if buf is NULL.  In this case, the allocated buffer has the length size unless size is zero, when buf
>       is allocated as big as necessary.  The caller should free(3) the returned buffer.

I suggest this glibc extension be used for the getcwd model to reduce false positives.