### PR TITLE
added `<version>` tag for `maven-compiler-plugin`

### DIFF
--- a/infer/src/integration/Maven.ml
+++ b/infer/src/integration/Maven.ml
@@ -22,6 +22,7 @@ let infer_profile =
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
             <configuration>
               <compilerId>javac</compilerId>
               <forceJavacCompilerUse>true</forceJavacCompilerUse>


### PR DESCRIPTION
fixes Maven 3 version missing warning for org.apache.maven.plugins:maven-compiler-plugin

fixes #990 