### PR TITLE
Remove function Utils.write_file_with_locking

### DIFF
--- a/infer/src/backend/PerfStats.ml
+++ b/infer/src/backend/PerfStats.ml
@@ -314,7 +314,7 @@ let report stats_kind file stats_type () =
       try
         Unix.mkdir_p (Filename.dirname file) ;
         (* the same report may be registered across different infer processes *)
-        Utils.write_file_with_locking file ~f:(fun stats_oc ->
+        Utils.with_intermediate_temp_file_out file ~f:(fun stats_oc ->
             Yojson.Basic.pretty_to_channel stats_oc json_stats )
       with exc ->
         L.internal_error "Info: failed to write stats to %s@\n%s@\n%s@\n%s@." file

--- a/infer/src/base/Utils.mli
+++ b/infer/src/base/Utils.mli
@@ -96,10 +96,6 @@ val compare_versions : string -> string -> int
     -1 if v1 is older than v2 and 0 if they are the same version.
     The versions are strings of the shape "n.m.t", the order is lexicographic. *)
 
-val write_file_with_locking : ?delete:bool -> f:(Out_channel.t -> unit) -> string -> unit
-(** Lock file passed as argument and write into it using [f]. If [delete] then the file is unlinked
-    once this is done. *)
-
 val rmtree : string -> unit
 (** [rmtree path] removes [path] and, if [path] is a directory, recursively removes its contents *)
 


### PR DESCRIPTION
`Utils.with_intermediate_temp_file_out` is conceptually simpler. Plus,
this removes a dependency on Unix.flock, which is not portable under
Windows.
