### PR TITLE
Point to the latest release

### DIFF
--- a/_docs/00-getting-started.md
+++ b/_docs/00-getting-started.md
@@ -21,7 +21,7 @@ latest [binary
 release](https://github.com/facebook/infer/releases/latest). Download
 the tarball then extract it anywhere on your system to start using
 infer. For example, this downloads infer in /opt on Linux (replace
-`VERSION` with the latest release, eg `VERSION=0.15.0`):
+`VERSION` with the latest release, eg `VERSION=0.16.0`):
 
 ```sh
 VERSION=0.XX.Y; \


### PR DESCRIPTION
Newcomers may not be aware which is the latest Infer version and will likely download version mentioned in _Getting started_ guide, so it should point to the latest release. Unfortunately, it is not possible to just point to the [latest](https://github.com/facebook/infer/releases/latest) release, because asset name currently contains version.