### PR TITLE
Improvements in docker container generation

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -22,12 +22,12 @@ RUN apt-get update && \
       make \
       openjdk-8-jdk-headless \
       patch \
+      patchelf \
       pkg-config \
       python2.7 \
       unzip \
       xz-utils \
-      zlib1g-dev \
-      patchelf && \
+      zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Some scripts in facebook-clang-plugins assume "python" is available
@@ -39,7 +39,7 @@ RUN curl -sL https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x8
 
 # Disable sandboxing
 # Without this opam fails to compile OCaml for some reason. We don't need sandboxing inside a Docker container anyway.
-RUN opam init --reinit --bare --disable-sandboxing -ya
+RUN opam init --reinit --bare --disable-sandboxing --yes --auto-setup
 
 # Download the latest Infer master
 RUN cd / && \
@@ -56,7 +56,12 @@ RUN cd /infer && \
     ./facebook-clang-plugins/clang/setup.sh
 
 # Generate a release
-RUN cd /infer && make install-with-libs BUILD_MODE=opt PATCHELF=patchelf DESTDIR="/infer-release" libdir_relative_to_bindir="../lib"
+RUN cd /infer && \ 
+    make install-with-libs \
+    BUILD_MODE=opt \ 
+    PATCHELF=patchelf \
+    DESTDIR="/infer-release" \ 
+    libdir_relative_to_bindir="../lib"
 
 FROM debian:stretch-slim AS executor 
 

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -sL https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x8
 
 # Disable sandboxing
 # Without this opam fails to compile OCaml for some reason. We don't need sandboxing inside a Docker container anyway.
-RUN opam init --reinit --bare --disable-sandboxing
+RUN opam init --reinit --bare --disable-sandboxing -ya
 
 # Download the latest Infer master
 RUN cd / && \

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:stretch-slim AS compilator
 
 LABEL maintainer "Infer team"
 
@@ -26,7 +26,8 @@ RUN apt-get update && \
       python2.7 \
       unzip \
       xz-utils \
-      zlib1g-dev && \
+      zlib1g-dev \
+      patchelf && \
     rm -rf /var/lib/apt/lists/*
 
 # Some scripts in facebook-clang-plugins assume "python" is available
@@ -54,20 +55,22 @@ RUN cd /infer && \
     ./configure && \
     ./facebook-clang-plugins/clang/setup.sh
 
-# Hackish for now: pull to get the latest version
-RUN cd /infer && git pull 
+# Generate a release
+RUN cd /infer && make install-with-libs BUILD_MODE=opt PATCHELF=patchelf DESTDIR="/infer-release" libdir_relative_to_bindir="../lib"
+
+FROM debian:stretch-slim AS executor 
+
+# Install python 2.7 since infer requires it to run
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+    python2.7
+
+# Get the infer release
+COPY --from=compilator /infer-release/usr/local /infer
+
+# Installl infer
+ENV PATH /infer/bin:${PATH}
 
 # if called with /infer-host mounted then copy infer there
 RUN if test -d /infer-host; then \
       cp -av /infer/. /infer-host; \
     fi
-
-# Install Infer
-ENV INFER_HOME /infer/infer
-ENV PATH ${INFER_HOME}/bin:${PATH}
-
-# build in non-optimized mode by default to speed up build times
-ENV BUILD_MODE=default
-
-# prevent exiting by compulsively hitting Control-D
-ENV IGNOREEOF=9


### PR DESCRIPTION
Using "opam init" in non interactive mode, in order to avoid compilation failures. Otherwise, It will wait for user input until a timeout, that will cause the compilation process to fail due to an OPAM error.

Also the Dockerfile has been modified in order to use [multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/), obtaining a cleaner Docker image.