### PR TITLE
Add missing dependency in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
     - ${HOME}/.opam
     - facebook-clang-plugins
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libmpfr-dev
   - wget -O ${HOME}/opam https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux
   - chmod +x ${HOME}/opam
   - export PATH=${HOME}:${PATH}


### PR DESCRIPTION
Adding dependencies via `apt` can fix the broken builds on master.

Should close #1174, and close #1125