### PR TITLE
Re-add OSX support for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,39 @@ addons:
   apt:
     packages:
     - libmpfr-dev
+  homebrew:
+    packages:
+      - aspcud
+      - automake
+      - gmp
+      - libtool
+      - lzlib
+      - mpfr
+      - pkg-config
+      - sqlite
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ARCH="darwin"; else ARCH="linux"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/bin:${PATH}"; fi
   - wget -O ${HOME}/opam https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-${ARCH}
   - chmod +x ${HOME}/opam
   - export PATH=${HOME}:${PATH}
   - export OPAMYES=1
   - export OPAMJOBS=2
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export OPAMEXTERNALSOLVER=$(which aspcud); fi
   - opam init --compiler=${OCAML_VERSION} --disable-sandboxing
   - eval $(opam env)
   - export OPAMVERBOSE=1
 install:
+  # ensure infer isn't installed in this switch, then deal with dependencies
+  - opam remove infer
   - opam update --upgrade
   - opam pin add --no-action infer .
-  - opam depext --update infer
+  - if [ "$TRAVIS_OS_NAME" != "osx" ]; then opam depext --update infer; fi
   - opam install --deps-only infer
 script:
   - opam install infer
+before_cache:
+  - opam remove infer
 os:
 - linux
+- osx


### PR DESCRIPTION
Re-add OSX support, and improve the general workflow of the current CI.

Edits made:

- (osx) use `homebrew` addon for system packages.

- (will result in safer builds on both osx and linux) Remove infer from opam switch before cache (keep builds more isolated, and prevent odd timeouts on archive packing on osx)
  - [`opam update --upgrade` fails](https://travis-ci.org/github/facebook/infer/builds/661635581?utm_source=github_status&utm_medium=notification) due to menhir/infer recompiling at the same time, while menhir is a dependency of infer (this happened in unrelated pr #1237 )
  - [archive timeout](https://travis-ci.org/github/facebook/infer/jobs/661141420?utm_medium=notification&utm_source=github_status) 

- (osx) do not run `opam depexts --upgrade` on macOS; if run, it will [unnecessarily call Homebrew](https://travis-ci.org/github/facebook/infer/jobs/662156953?utm_medium=notification&utm_source=github_status), resulting in a longer build

- (osx) Use aspcud on osx as an external solver, otherwise opam runs out of memory
  - [related build](https://travis-ci.org/github/facebook/infer/builds/660931619?utm_medium=notification&utm_source=github_status)
<details>
<pre>
opam(4068,0x7fffb59d9380) malloc: *** mach_vm_map(size=3039929774538752) failed (error code=3)
*** error: can't allocate region
*** set a breakpoint in malloc_error_break to debug
Fatal error: out of memory.
The command "opam update --upgrade" failed and exited with 2 during .
</pre>
</details>