### PR TITLE
Release infer annotations 0.17.1

### DIFF
--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.17.1-SNAPSHOT</version>
+  <version>0.17.1</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:git@github.com:facebook/infer.git</connection>
     <developerConnection>scm:git:git@github.com:facebook/infer.git</developerConnection>
     <url>https://github.com/facebook/infer</url>
-    <tag>infer-annotation-0.17.0</tag>
+    <tag>infer-annotation-0.17.1</tag>
   </scm>
 
   <developers>

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:git@github.com:facebook/infer.git</connection>
     <developerConnection>scm:git:git@github.com:facebook/infer.git</developerConnection>
     <url>https://github.com/facebook/infer</url>
-    <tag>infer-annotation-0.17.1</tag>
+    <tag>infer-annotation-0.17.0</tag>
   </scm>
 
   <developers>

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -55,7 +55,7 @@
     <repository>
       <id>sonatype-nexus-staging</id>
       <name>Nexus Release Repository</name>
-      <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -85,6 +85,11 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The artifact is released on sonatype: https://oss.sonatype.org/service/local/repositories/releases/content/com/facebook/infer/annotation/infer-annotation/0.17.1/infer-annotation-0.17.1.jar
and soon should be propagated to Maven Central (usually, within 2hrs).