### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 sudo: required
 env:
-  - OCAML_VERSION=4.07.1
+  - OCAML_VERSION=4.08.1
 cache:
   directories:
     - ${HOME}/.opam


### PR DESCRIPTION
The CI script complains because it's trying to build infer with an old version of ocaml, so to remedy this I bumped the ocaml version in CI. It looks like the CI passes with this change, I did some testing on my own fork of infer and got the CI job to pass in Travis.