### PR TITLE
Revert "update macOS install with tap"

### DIFF
--- a/_docs/00-getting-started.md
+++ b/_docs/00-getting-started.md
@@ -10,13 +10,7 @@ permalink: /docs/getting-started.html
 You can use Homebrew (Mac only), our binary releases, build infer from
 source, or use our Docker image.
 
-On Mac (Mojave), the simplest way is to use [Homebrew](http://brew.sh/). There is a user-provided tap for infer. Type this into a terminal:
-
-```sh
-brew install amar1729/infer/infer
-```
-
-For Mac pre-Mojave, use Homebrew core:
+On Mac, the simplest way is to use [Homebrew](http://brew.sh/). Type this into a terminal:
 
 ```sh
 brew install infer


### PR DESCRIPTION
This reverts commit acc657b45a3829e090197fe85776062e9158430a.

Now that Homebrew contributors have fixed its version of `infer`, I'll deprecate my tap for it.

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
