### PR TITLE
Release infer-annotations 0.17.2

### DIFF
--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.17.2</version>
+  <version>0.17.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:git@github.com:facebook/infer.git</connection>
     <developerConnection>scm:git:git@github.com:facebook/infer.git</developerConnection>
     <url>https://github.com/facebook/infer</url>
-    <tag>infer-annotation-0.17.2</tag>
+    <tag>infer-annotation-0.17.0</tag>
   </scm>
 
   <developers>

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.17.2-SNAPSHOT</version>
+  <version>0.17.2</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:git@github.com:facebook/infer.git</connection>
     <developerConnection>scm:git:git@github.com:facebook/infer.git</developerConnection>
     <url>https://github.com/facebook/infer</url>
-    <tag>infer-annotation-0.17.0</tag>
+    <tag>infer-annotation-0.17.2</tag>
   </scm>
 
   <developers>


### PR DESCRIPTION
The artifact is released on sonatype:
https://oss.sonatype.org/service/local/repositories/releases/content/com/facebook/infer/annotation/infer-annotation/0.17.2/infer-annotation-0.17.2.jar
and soon should be propagated to Maven Central (usually, within 2hrs).