### PR TITLE
Removing references to the previously removed (and now incorrect) '--no-test'

### DIFF
--- a/website/docs/01-advanced-features.md
+++ b/website/docs/01-advanced-features.md
@@ -66,9 +66,7 @@ Moreover, we obtain an HTML page for each captured file inside
 the file there are links to the nodes of the control flow graph that correspond
 to that line of code. So one can see what the translation looks like. Moreover,
 when you click on those links you can see details of the symbolic execution of
-that particular node. If the option `--no_test` is also passed to `infer`, then
-the page pointed to from the nodes contains the printout of the whole symbolic
-execution.
+that particular node.
 
 ## Print the specs
 


### PR DESCRIPTION
Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>

## Issue

Commit [068622c](https://github.com/facebook/infer/commit/068622c) renamed the option `test` to be `only-cheap-debug` and also flipped the default value. Therefore, what used to be `--no-test` (i.e., you _do_ want expensive debug information) is now `--no-only-cheap-debug`.

However, [`01-advanced-features.md`](https://github.com/facebook/infer/blob/master/website/docs/01-advanced-features.md) listed the option as `no_test` (with an underscore rather than a hyphen), which I guess got missed when renaming the option/changing the default.

The suggestion to use `--no_test` was recently suggested in [#1252](https://github.com/facebook/infer/issues/1252#issuecomment-618922148), so we should probably remove this, otherwise you get (even if you use the "correct" syntax for an older Infer):

```
$ infer --no-test
/path/to/infer/bin/infer: unknown option '--no-test'.
```

## Description of changes

Given that `only-cheap-debug` now has a default of _false_ (i.e., if you request `-g`/`--debug`, you automatically get `--no-only-cheap-debug`), making the suggestion to users to turn _off_ "no expensive debugging" is not required.

Consequently, this PR removes the recommendation to pass `--no-test`/`--no-only-cheap-debug` in the documentation.
