### PR TITLE
fix link to FAQ in issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please make sure your issue is not addressed in the [FAQ](http://fbinfer.com/support.html#troubleshooting).
+Please make sure your issue is not addressed in the [FAQ](https://fbinfer.com/docs/support#troubleshooting).
 
 Please include the following information:
 - [ ] The version of infer from `infer --version`.


### PR DESCRIPTION
The current [link](http://fbinfer.com/support.html#troubleshooting) results in a 404 "page not found" error. Also updated to https since the website redirects to https anyway.