### PR TITLE
Release infer-annotation 0.18.0

### DIFF
--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.17.3-SNAPSHOT</version>
+  <version>0.18.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>
@@ -25,7 +25,7 @@
     <connection>scm:git:git@github.com:facebook/infer.git</connection>
     <developerConnection>scm:git:git@github.com:facebook/infer.git</developerConnection>
     <url>https://github.com/facebook/infer</url>
-    <tag>infer-annotation-0.17.0</tag>
+    <tag>infer-annotation-0.18.0</tag>
   </scm>
 
   <developers>

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.18.0</version>
+  <version>0.18.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>

--- a/infer/annotations/pom.xml
+++ b/infer/annotations/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.facebook.infer.annotation</groupId>
   <artifactId>infer-annotation</artifactId>
-  <version>0.18.0-SNAPSHOT</version>
+  <version>0.18.0</version>
   <packaging>jar</packaging>
   <description>Annotations for the Infer static analyzer</description>
   <url>http://fbinfer.com/</url>


### PR DESCRIPTION
Due to:
1. Additional dependency on kotlin-annotations,
2. @nullsafe annotation being annotated as @TypeQualifierDefault and
@UnderMigration(status = STRICT) [which can have breaking effect on
Kotlin code],
let's bump the minor version of the artifact.