### PR TITLE
Update CI to build infer with c analyzers

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -78,3 +78,44 @@ jobs:
       - run: opam install --deps-only infer
 
       - run: opam install infer
+
+      - name: Test infer
+        run: |
+          eval $(opam env)
+
+          echo -e "#include <stdio.h> \n int main() { int *s = NULL; *s = 42; return 0; } " > FailingTest.c
+          echo -e "#include <stdio.h> \n int main() { int *s = NULL; if (s != NULL) { *s = 42; } return 0; }" > PassingTest.c
+
+          # first command should exit with status 2
+          infer --fail-on-issue -P -- clang -c FailingTest.c || if [[ $? -ne 2 ]]; then exit 1; fi
+          infer --fail-on-issue -P -- clang -c PassingTest.c
+
+          echo 'class FailingTest {' >> FailingTest.java
+          echo '  String mayReturnNull(int i) {' >> FailingTest.java
+          echo '    if (i > 0) {' >> FailingTest.java
+          echo '      return "Hello, Infer!";' >> FailingTest.java
+          echo '    }' >> FailingTest.java
+          echo '    return null;' >> FailingTest.java
+          echo '  }' >> FailingTest.java
+          echo '  int mayCauseNPE() {' >> FailingTest.java
+          echo '    String s = mayReturnNull(0);' >> FailingTest.java
+          echo '    return s.length();' >> FailingTest.java
+          echo '  }' >> FailingTest.java
+          echo '}' >> FailingTest.java
+
+          echo "  class PassingTest {" >> PassingTest.java
+          echo "    String mayReturnNull(int i) {" >> PassingTest.java
+          echo "      if (i > 0) {" >> PassingTest.java
+          echo '        return "Hello, Infer!";' >> PassingTest.java
+          echo "      }" >> PassingTest.java
+          echo "      return null;" >> PassingTest.java
+          echo "    }" >> PassingTest.java
+          echo "    int mayCauseNPE() {" >> PassingTest.java
+          echo "      String s = mayReturnNull(0);" >> PassingTest.java
+          echo "      return s == null ? 0 : s.length();" >> PassingTest.java
+          echo "    }" >> PassingTest.java
+          echo "  }" >> PassingTest.java
+
+          # first command should exit with status 2
+          infer --fail-on-issue -P -- javac FailingTest.java || if [[ $? -ne 2 ]]; then exit 1; fi
+          infer --fail-on-issue -P -- javac PassingTest.java

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macOS-latest
           - ubuntu-latest
         ocaml-version:
           - 4.09.1
@@ -35,8 +35,36 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('opam.locked') }}
 
       - name: Install Required Brew Packages for MacOS
-        run: brew install pkg-config automake
+        run: brew install pkg-config automake jq
         if: runner.os == 'macOS'
+
+      - name: Fetch clang Release
+        run: |
+          REPO="facebook/facebook-clang-plugins"
+          URL="https://api.github.com/repos/$REPO"
+
+          CLANGFILE="clang-install-${{ matrix.os }}.tar.gz"
+
+          RELEASE_INFO="$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$URL/releases/latest")"
+          if ! ASSET_ID="$(jq ".assets | map(select(.name == \"$CLANGFILE\"))[0].id" <<< "$RELEASE_INFO")"; then
+              echo "$RELEASE_INFO"
+              exit 1
+          fi
+
+          if [[ -z "$ASSET_ID" || "$ASSET_ID" == "null" ]]; then
+              echo "Could not find asset ID" >&2
+              exit 1
+          fi
+
+          curl -J -L "$URL/releases/assets/$ASSET_ID" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/octet-stream" \
+              -o "$CLANGFILE"
+
+      - run: tar -xzf clang-install-${{ matrix.os }}.tar.gz -C facebook-clang-plugins/clang/
+
+      # let the build run with c analyzers enabled
+      - run: sed -i -e '/"--disable-c-analyzers"/d' opam opam.locked
 
       # ensure infer isn't installed in this switch, then deal with dependencies
       - run: opam remove infer || true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -65,6 +65,7 @@ jobs:
 
       # let the build run with c analyzers enabled
       - run: sed -i -e '/"--disable-c-analyzers"/d' opam opam.locked
+      - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
 
       # ensure infer isn't installed in this switch, then deal with dependencies
       - run: opam remove infer || true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -63,8 +63,7 @@ jobs:
 
       - run: tar -xzf clang-install-${{ matrix.os }}.tar.gz -C facebook-clang-plugins/clang/
 
-      # is this needed?
-      # - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
+      - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
 
       # ensure infer isn't installed in this switch, then deal with dependencies
       - run: opam remove infer || true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -63,9 +63,8 @@ jobs:
 
       - run: tar -xzf clang-install-${{ matrix.os }}.tar.gz -C facebook-clang-plugins/clang/
 
-      # let the build run with c analyzers enabled
-      - run: sed -i -e '/"--disable-c-analyzers"/d' opam opam.locked
-      - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
+      # is this needed?
+      # - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
 
       # ensure infer isn't installed in this switch, then deal with dependencies
       - run: opam remove infer || true

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -84,39 +84,52 @@ jobs:
         run: |
           eval $(opam env)
 
-          echo -e "#include <stdio.h> \n int main() { int *s = NULL; *s = 42; return 0; } " > FailingTest.c
-          echo -e "#include <stdio.h> \n int main() { int *s = NULL; if (s != NULL) { *s = 42; } return 0; }" > PassingTest.c
+          {
+            echo 'class FailingTest {'
+            echo '  String mayReturnNull(int i) {'
+            echo '    if (i > 0) {'
+            echo '      return "Hello, Infer!";'
+            echo '    }'
+            echo '    return null;'
+            echo '  }'
+            echo '  int mayCauseNPE() {'
+            echo '    String s = mayReturnNull(0);'
+            echo '    return s.length();'
+            echo '  }'
+            echo '}'
+          } > FailingTest.java
 
-          # first command should exit with status 2
-          infer --fail-on-issue -P -- clang -c FailingTest.c || if [[ $? -ne 2 ]]; then exit 1; fi
-          infer --fail-on-issue -P -- clang -c PassingTest.c
-
-          echo 'class FailingTest {' >> FailingTest.java
-          echo '  String mayReturnNull(int i) {' >> FailingTest.java
-          echo '    if (i > 0) {' >> FailingTest.java
-          echo '      return "Hello, Infer!";' >> FailingTest.java
-          echo '    }' >> FailingTest.java
-          echo '    return null;' >> FailingTest.java
-          echo '  }' >> FailingTest.java
-          echo '  int mayCauseNPE() {' >> FailingTest.java
-          echo '    String s = mayReturnNull(0);' >> FailingTest.java
-          echo '    return s.length();' >> FailingTest.java
-          echo '  }' >> FailingTest.java
-          echo '}' >> FailingTest.java
-
-          echo "  class PassingTest {" >> PassingTest.java
-          echo "    String mayReturnNull(int i) {" >> PassingTest.java
-          echo "      if (i > 0) {" >> PassingTest.java
-          echo '        return "Hello, Infer!";' >> PassingTest.java
-          echo "      }" >> PassingTest.java
-          echo "      return null;" >> PassingTest.java
-          echo "    }" >> PassingTest.java
-          echo "    int mayCauseNPE() {" >> PassingTest.java
-          echo "      String s = mayReturnNull(0);" >> PassingTest.java
-          echo "      return s == null ? 0 : s.length();" >> PassingTest.java
-          echo "    }" >> PassingTest.java
-          echo "  }" >> PassingTest.java
+          {
+            echo "  class PassingTest {"
+            echo "    String mayReturnNull(int i) {"
+            echo "      if (i > 0) {"
+            echo '        return "Hello, Infer!";'
+            echo "      }"
+            echo "      return null;"
+            echo "    }"
+            echo "    int mayCauseNPE() {"
+            echo "      String s = mayReturnNull(0);"
+            echo "      return s == null ? 0 : s.length();"
+            echo "    }"
+            echo "  }"
+          } > PassingTest.java
 
           # first command should exit with status 2
           infer --fail-on-issue -P -- javac FailingTest.java || if [[ $? -ne 2 ]]; then exit 1; fi
           infer --fail-on-issue -P -- javac PassingTest.java
+
+          {
+            echo "#include <stdio.h>"
+            echo "int main()"
+            echo "{ int *s = NULL; *s = 42; return 0; } "
+          } > FailingTest.c
+
+          {
+            echo "#include <stdio.h>"
+            echo "int main()"
+            echo "{ int *s = NULL; if (s != NULL) { *s = 42; } return 0; }"
+          } > PassingTest.c
+
+          # first command should exit with status 2
+          infer --fail-on-issue -P -- clang -c FailingTest.c || if [[ $? -ne 2 ]]; then exit 1; fi
+          infer --fail-on-issue -P -- clang -c PassingTest.c

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,6 +38,10 @@ jobs:
         run: brew install pkg-config automake jq
         if: runner.os == 'macOS'
 
+      - name: Install Required Apt Packages for Ubuntu
+        run: sudo apt-get install libmpfr-dev libsqlite3-dev
+        if: runner.os == 'Linux'
+
       - name: Fetch clang Release
         run: |
           REPO="facebook/facebook-clang-plugins"
@@ -65,18 +69,13 @@ jobs:
 
       - run: ./facebook-clang-plugins/clang/setup.sh --only-record-install
 
-      # ensure infer isn't installed in this switch, then deal with dependencies
-      - run: opam remove infer || true
+      - run: ./build-infer.sh -y all
 
-      - run: opam update --upgrade
+      - run: make install
+        if: runner.os == 'macOS'
 
-      - run: opam pin add --no-action infer .
-
-      - run: opam depext --update infer;
-
-      - run: opam install --deps-only infer
-
-      - run: opam install infer
+      - run: sudo make install
+        if: runner.os == 'Linux'
 
       - name: Test infer
         run: |

--- a/opam
+++ b/opam
@@ -11,7 +11,6 @@ license: "MIT"
 build: [
   ["./autogen.sh"]
   ["./configure"
-     "--disable-c-analyzers"
      "--prefix=%{prefix}%"]
   [make "-j" jobs]
   [make "-j" jobs "config_tests"] {with-test}

--- a/opam.locked
+++ b/opam.locked
@@ -11,7 +11,6 @@ license: "MIT"
 build: [
   ["./autogen.sh"]
   ["./configure"
-     "--disable-c-analyzers"
      "--prefix=%{prefix}%"]
   [make "-j" jobs]
   [make "-j" jobs "config_tests"] {with-test}


### PR DESCRIPTION
After merging https://github.com/facebook/facebook-clang-plugins/pull/20, we can now use Actions here to download a facebook-clang custom clang Release here and use it to build C Analyzers during CI, as well as Java Analyzers.

1. had to change `matrix.os: macos-latest` to `matrix.os: macOS-latest`. I guess that's what I typed for the fb clang build, and `curl`ing a Release asset is case-sensitive.

2. Add `jq` to installed packages on mac - we need it for parsing GitHub's API responses

3. Add the logic for fetching a release asset (we currently only look for the `"latest"` release) and downloading the properly-named clang based on OS. Then unpack it and update the `opam` files so we build with clang.


Note: I would have used this Action: https://github.com/dsaltares/fetch-gh-release-asset/ for fetching a Release asset, but unfortunately it seems to be in a fairly new state and it's a Docker Action, which means it doesn't support macOS. The logic in the fetch clang step is roughly based off of this action's logic.