### PR TITLE
Fix link on release page.

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -34,7 +34,7 @@ jobs:
             7. Tweet.
             --- DELETE EVERYTHING ABOVE THIS LINE ---
 
-            This is a binary release of Infer for Linux and MacOS. To use it follow these [instructions](http://fbinfer.com/docs/getting-started.html).
+            This is a binary release of Infer for Linux and MacOS. To use it follow these [instructions](http://fbinfer.com/docs/getting-started).
 
             - new feature 1
             - new feature 2


### PR DESCRIPTION
This patch fixes the link to the "getting started" page on the infer release page.

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
