### PR TITLE
Use `--depth` flag to `git clone` in Dockerfiles, to save space

### DIFF
--- a/docker/master-java/Dockerfile
+++ b/docker/master-java/Dockerfile
@@ -37,7 +37,7 @@ RUN opam init --reinit --bare --disable-sandboxing
 
 # Download the latest Infer master
 RUN cd / && \
-    git clone https://github.com/facebook/infer/
+    git clone --depth 1 https://github.com/facebook/infer/
 
 # Build opam deps first, then infer. This way if any step fails we
 # don't lose the significant amount of work done in the previous

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -41,7 +41,7 @@ RUN opam init --reinit --bare --disable-sandboxing --yes --auto-setup
 
 # Download the latest Infer master
 RUN cd / && \
-    git clone --recurse-submodules https://github.com/facebook/infer/
+    git clone --depth 1 --recurse-submodules https://github.com/facebook/infer/
 
 # Build opam deps first, then clang, then infer. This way if any step
 # fails we don't lose the significant amount of work done in the


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>