### PR TITLE
Fix Infer Installation Procedure

### DIFF
--- a/website/docs/00-getting-started.md
+++ b/website/docs/00-getting-started.md
@@ -25,7 +25,7 @@ latest release, eg `VERSION=0.17.0`):
 VERSION=0.XX.Y; \
 curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
 | sudo tar -C /opt -xJ && \
-ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+sudo ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
 ```
 
 If the binaries do not work for you, or if you would rather build infer from


### PR DESCRIPTION
Similar to the `tar` command, append `sudo` to the `ln` command since it fails due to 'Permission Denied' errors on Linux
