### PR TITLE
Fix compilation warning with gcc10

### DIFF
--- a/infer/src/c_stubs/fnv64_hash.c
+++ b/infer/src/c_stubs/fnv64_hash.c
@@ -23,7 +23,7 @@ uint64_t fnv64_hash_impl(const char* s) {
 }
 
 CAMLprim value fnv64_hash(value c) {
-  char* c_string = String_val(c);
+  const char* c_string = String_val(c);
   uint64_t hashed = fnv64_hash_impl(c_string);
   char str[21];
   snprintf(str, 21, "%" PRIu64, hashed);


### PR DESCRIPTION
gcc warnings are more strict starting from gcc10. Not having the const
qualifier triggers an error.
