### PR TITLE
Win32 (MinGW) support

### DIFF
--- a/Makefile.autoconf.in
+++ b/Makefile.autoconf.in
@@ -82,14 +82,7 @@ XCODE_BASE = @XCODE_BASE@
 XCODE_SELECT = @XCODE_SELECT@
 XCPRETTY = @XCPRETTY@
 XCRUN = @XCRUN@
-
-ifneq (,$(findstring s,$(MAKEFLAGS)))
-# quiet mode
 LN_S = @LN_S@
-else
-LN_S = @LN_S@ -v
-endif
-
 # Export parts of the config relevant to running other programs
 export PATH := $(PATH)
 export CPATH := $(CPATH)

--- a/infer/src/IR/Procname.ml
+++ b/infer/src/IR/Procname.ml
@@ -947,7 +947,7 @@ let to_filename pname =
     | _ ->
         F.asprintf "%a" pp_unique_id pname
   in
-  DB.append_crc_cutoff proc_id |> fst
+  DB.append_crc_cutoff proc_id |> fst |> Escape.escape_filename
 
 
 module SQLite = struct

--- a/infer/src/base/CommandLineOption.ml
+++ b/infer/src/base/CommandLineOption.ml
@@ -1049,7 +1049,7 @@ let parse ?config_file ~usage action initial_command =
          environment contributes to the length of the command to be run. If the environment + CLI is
          too big, running any command will fail with a cryptic "exit code 127" error. Use an argfile
          to prevent this from happening *)
-      let file = Filename.temp_file "args" "" in
+      let file = Filename.temp_file "infer_args" "" in
       Out_channel.with_file file ~f:(fun oc -> Out_channel.output_lines oc argv_to_export) ;
       if not !keep_args_file then Utils.unlink_file_on_exit file ;
       "@" ^ file )

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -1317,6 +1317,13 @@ and force_integration =
        |> String.concat ~sep:", " ))
 
 
+and fork_mode =
+  CLOpt.mk_bool ~long:"fork-mode"
+    ~default:(not (Stdlib.( = ) Version.build_platform Version.Windows))
+    "Use 'fork' system call to spawn sub-processes. If not set, use the equivalent of 'fork/exec' \
+     -- which  is usually slower, but is available on all OSes."
+
+
 and from_json_report =
   CLOpt.mk_path_opt ~long:"from-json-report"
     ~in_help:InferCommand.[(Report, manual_generic)]
@@ -2109,6 +2116,12 @@ and results_dir =
         ; (Run, manual_generic)
         ; (Report, manual_generic) ]
     ~meta:"dir" "Write results and internal files in the specified directory"
+
+
+and run_as_child =
+  CLOpt.mk_int_opt ~in_help:[] ~long:"run-as-child"
+    "Enable child mode. The integer argument is the identity of the child. This is an internal \
+     option."
 
 
 and seconds_per_iteration =
@@ -2922,6 +2935,8 @@ and force_delete_results_dir = !force_delete_results_dir
 
 and force_integration = !force_integration
 
+and fork_mode = !fork_mode
+
 and from_json_report =
   Option.value !from_json_report
     ~default:(ResultsDirEntryName.get_path ~results_dir:!results_dir ReportJson)
@@ -3116,7 +3131,7 @@ and process_clang_ast = !process_clang_ast
 and progress_bar =
   if !progress_bar && not !quiet then
     match !progress_bar_style with
-    | `Auto when Unix.(isatty stdin && isatty stderr) ->
+    | `Auto when Unix.(isatty stdin && isatty stderr) || not (Option.is_none !run_as_child) ->
         `MultiLine
     | `Auto ->
         `Plain
@@ -3223,6 +3238,8 @@ and report_suppress_errors = RevList.to_list !report_suppress_errors
 and reports_include_ml_loc = !reports_include_ml_loc
 
 and results_dir = !results_dir
+
+and run_as_child = !run_as_child
 
 and scheduler = !scheduler
 

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -2635,7 +2635,7 @@ let post_parsing_initialization command_opt =
   let uncaught_exception_handler exn raw_backtrace =
     let is_infer_exit_zero = match exn with L.InferExit 0 -> true | _ -> false in
     let should_print_backtrace_default =
-      match exn with L.InferUserError _ | L.InferExit _ -> false | _ -> true
+      match exn with L.InferUserError _ | L.InferExit _ | Epilogues.Sigint -> false | _ -> true
     in
     let suggest_keep_going = should_print_backtrace_default && not !keep_going in
     let backtrace =
@@ -2656,6 +2656,8 @@ let post_parsing_initialization command_opt =
           error "Internal Error: " msg
       | L.InferUserError msg ->
           error "Usage Error: " msg
+      | Epilogues.Sigint ->
+          error "Process received signal SIGINT: " (Pid.to_string (ProcessPoolState.get_pid ()))
       | L.InferExit _ ->
           ()
       | _ ->

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -122,6 +122,8 @@ val report_immutable_modifications : bool
 
 val report_nullable_inconsistency : bool
 
+val run_as_child : int option
+
 val save_compact_summaries : bool
 
 val smt_output : bool
@@ -297,6 +299,8 @@ val filtering : bool
 val force_delete_results_dir : bool
 
 val force_integration : build_system option
+
+val fork_mode : bool
 
 val from_json_report : string
 

--- a/infer/src/base/DB.ml
+++ b/infer/src/base/DB.ml
@@ -15,6 +15,8 @@ module L = Logging
 
 let cutoff_length = 100
 
+let crc_only = Stdlib.( = ) Version.Windows Version.build_platform
+
 let crc_token = '.'
 
 let append_crc_cutoff ?(key = "") name =
@@ -23,9 +25,10 @@ let append_crc_cutoff ?(key = "") name =
   in
   let crc_str =
     let name_for_crc = name ^ key in
-    Utils.string_crc_hex32 name_for_crc
+    String.sub (Utils.string_crc_hex32 name_for_crc) ~pos:0 ~len:16
   in
-  (Printf.sprintf "%s%c%s" name_up_to_cutoff crc_token crc_str, crc_str)
+  if crc_only then (crc_str, crc_str)
+  else (Printf.sprintf "%s%c%s" name_up_to_cutoff crc_token crc_str, crc_str)
 
 
 let curr_source_file_encoding = `Enc_crc

--- a/infer/src/base/DBWriter.ml
+++ b/infer/src/base/DBWriter.ml
@@ -385,7 +385,10 @@ module Server = struct
         send Command.Handshake
 end
 
-let use_daemon = Config.((not (buck || genrule_mode)) && jobs > 1)
+let use_daemon =
+  Config.((not (buck || genrule_mode)) && jobs > 1)
+  && match Version.build_platform with Linux | Darwin -> true | Windows -> false
+
 
 let perform cmd = if use_daemon then Server.send cmd else Command.execute cmd
 

--- a/infer/src/base/Epilogues.mli
+++ b/infer/src/base/Epilogues.mli
@@ -19,3 +19,5 @@ val register_late : f:(unit -> unit) -> description:string -> unit
 val run : unit -> unit
 
 val reset : unit -> unit
+
+exception Sigint

--- a/infer/src/base/ForkUtils.ml
+++ b/infer/src/base/ForkUtils.ml
@@ -9,8 +9,11 @@ open! IStd
 module L = Logging
 
 let protect ~f x =
-  Epilogues.reset () ;
-  L.reset_formatters () ;
+  (* Some steps must be done only in 'fork' mode. In fork-exec mode, the process just went through
+     Infer's initialization phase, and those steps need not be redone. *)
+  if Option.is_none Config.run_as_child then (
+    Epilogues.reset () ;
+    L.reset_formatters () ) ;
   ResultsDatabase.new_database_connection () ;
   (* get different streams of random numbers in each fork, in particular to lessen contention in
      `Filename.mk_temp` *)

--- a/infer/src/base/Process.ml
+++ b/infer/src/base/Process.ml
@@ -67,30 +67,17 @@ let create_process_and_wait_with_output ~prog ~args action =
 
 let pipeline ~producer_prog ~producer_args ~consumer_prog ~consumer_args =
   let pipe_in, pipe_out = Unix.pipe () in
-  match Unix.fork () with
-  | `In_the_child ->
-      (* redirect producer's stdout to pipe_out *)
-      Unix.dup2 ~src:pipe_out ~dst:Unix.stdout () ;
-      (* close producer's copy of pipe ends *)
-      Unix.close pipe_out ;
-      Unix.close pipe_in ;
-      (* exec producer *)
-      never_returns (Unix.exec ~prog:producer_prog ~argv:producer_args ())
-  | `In_the_parent producer_pid -> (
-    match Unix.fork () with
-    | `In_the_child ->
-        (* redirect consumer's stdin to pipe_in *)
-        Unix.dup2 ~src:pipe_in ~dst:Unix.stdin () ;
-        (* close consumer's copy of pipe ends *)
-        Unix.close pipe_out ;
-        Unix.close pipe_in ;
-        (* exec consumer *)
-        never_returns (Unix.exec ~prog:consumer_prog ~argv:consumer_args ())
-    | `In_the_parent consumer_pid ->
-        (* close parent's copy of pipe ends *)
-        Unix.close pipe_out ;
-        Unix.close pipe_in ;
-        (* wait for children *)
-        let producer_status = Unix.waitpid producer_pid in
-        let consumer_status = Unix.waitpid consumer_pid in
-        (producer_status, consumer_status) )
+  let producer_args = Array.of_list producer_args in
+  let consumer_args = Array.of_list consumer_args in
+  let producer_pid =
+    Caml_unix.create_process producer_prog producer_args Unix.stdin pipe_out Unix.stderr
+  in
+  let consumer_pid =
+    Caml_unix.create_process consumer_prog consumer_args pipe_in Unix.stdout Unix.stderr
+  in
+  (* wait for children *)
+  let producer_status = Unix.waitpid (Pid.of_int producer_pid) in
+  let consumer_status = Unix.waitpid (Pid.of_int consumer_pid) in
+  Unix.close pipe_out ;
+  Unix.close pipe_in ;
+  (producer_status, consumer_status)

--- a/infer/src/base/ProcessPool.ml
+++ b/infer/src/base/ProcessPool.ml
@@ -191,15 +191,8 @@ let killall pool ~slot status =
 
 
 let has_dead_child pool =
-  let open Option.Monad_infix in
-  Unix.wait_nohang `Any
-  >>= fun (dead_pid, status) ->
-  (* Some joker can [exec] an infer binary from a process that already has children. When some of
-     these pre-existing children die they'll get detected here but won't appear in our list of
-     workers. Just return [None] in that case. *)
   Array.find_mapi pool.slots ~f:(fun slot {pid} ->
-      if Pid.equal pid dead_pid then Some slot else None )
-  >>| fun slot -> (slot, status)
+      Unix.wait_nohang (`Pid pid) |> Option.map ~f:(fun (_dead_pid, status) -> (slot, status)) )
 
 
 let child_is_idle = function Idle -> true | _ -> false

--- a/infer/src/base/ProcessPool.ml
+++ b/infer/src/base/ProcessPool.ml
@@ -360,6 +360,54 @@ let rec child_loop ~slot send_to_parent send_final receive_from_parent ~f ~epilo
         ~prev_result:result
 
 
+(** This function implements what the [slot]th child worker is supposed to do:
+
+    - execute [child_prologue]
+    - execute [f] in a loop
+    - once the loop ends, transmits the results of calling [epilogue] to the parent
+    - receives orders from [orders_ic], send status updates through [updates_oc]
+
+    Children never return. Instead they exit when done. *)
+let child slot ~f ~child_prologue ~epilogue ~updates_oc ~orders_ic =
+  (* Pin to a core. [setcore] does the modulo <number of cores> for us. *)
+  Utils.set_best_cpu_for slot ;
+  ProcessPoolState.in_child := true ;
+  child_prologue () ;
+  let send_to_parent (message : 'b worker_message) = marshal_to_pipe updates_oc message in
+  let send_final (final_message : 'a final_worker_message) =
+    marshal_to_pipe updates_oc final_message
+  in
+  (* Function to send updates up the pipe to the parent instead of directly to the task
+     bar. This is because only the parent knows about all the children, hence it's in charge of
+     actually updating the task bar. *)
+  let update_status t status =
+    match Config.progress_bar with
+    | `Quiet | `Plain ->
+        ()
+    | `MultiLine ->
+        let status =
+          (* Truncate status if too big: it's pointless to spam the status bar with long status, and
+             also difficult to achieve technically over pipes (it's easier if all the messages fit
+             into a buffer of reasonable size). *)
+          if String.length status > 100 then String.subo ~len:100 status ^ "..." else status
+        in
+        send_to_parent (UpdateStatus (slot, t, status))
+  in
+  ProcessPoolState.update_status := update_status ;
+  let receive_from_parent () =
+    PerfEvent.log (fun logger ->
+        PerfEvent.log_begin_event logger ~categories:["sys"] ~name:"receive from pipe" () ) ;
+    let x = Marshal.from_channel orders_ic in
+    PerfEvent.(log (fun logger -> log_end_event logger ())) ;
+    x
+  in
+  child_loop ~slot send_to_parent send_final receive_from_parent ~f ~epilogue ~prev_result:None ;
+  Out_channel.close updates_oc ;
+  In_channel.close orders_ic ;
+  Epilogues.run () ;
+  Stdlib.exit 0
+
+
 (** Fork a new child and start it so that it is ready for work.
 
     The child inherits [updates_w] to send updates up to the parent, and a new pipe is set up for
@@ -370,50 +418,64 @@ let fork_child ~child_prologue ~slot (updates_r, updates_w) ~f ~epilogue =
   | `In_the_child ->
       Unix.close updates_r ;
       Unix.close to_child_w ;
-      (* Pin to a core. [setcore] does the modulo <number of cores> for us. *)
-      Utils.set_best_cpu_for slot ;
-      ProcessPoolState.in_child := true ;
       ProcessPoolState.reset_pid () ;
-      child_prologue () ;
       let updates_oc = Unix.out_channel_of_descr updates_w in
-      let send_to_parent (message : 'b worker_message) = marshal_to_pipe updates_oc message in
-      let send_final (final_message : 'a final_worker_message) =
-        marshal_to_pipe updates_oc final_message
-      in
-      (* Function to send updates up the pipe to the parent instead of directly to the task
-         bar. This is because only the parent knows about all the children, hence it's in charge of
-         actually updating the task bar. *)
-      let update_status t status =
-        match Config.progress_bar with
-        | `Quiet | `Plain ->
-            ()
-        | `MultiLine ->
-            let status =
-              (* Truncate status if too big: it's pointless to spam the status bar with long status, and
-                 also difficult to achieve technically over pipes (it's easier if all the messages fit
-                 into a buffer of reasonable size). *)
-              if String.length status > 100 then String.subo ~len:100 status ^ "..." else status
-            in
-            send_to_parent (UpdateStatus (slot, t, status))
-      in
-      ProcessPoolState.update_status := update_status ;
       let orders_ic = Unix.in_channel_of_descr to_child_r in
-      let receive_from_parent () =
-        PerfEvent.log (fun logger ->
-            PerfEvent.log_begin_event logger ~categories:["sys"] ~name:"receive from pipe" () ) ;
-        let x = Marshal.from_channel orders_ic in
-        PerfEvent.(log (fun logger -> log_end_event logger ())) ;
-        x
-      in
-      child_loop ~slot send_to_parent send_final receive_from_parent ~f ~epilogue ~prev_result:None ;
-      Out_channel.close updates_oc ;
-      In_channel.close orders_ic ;
-      Epilogues.run () ;
-      Stdlib.exit 0
+      child slot ~f ~child_prologue ~epilogue ~updates_oc ~orders_ic
   | `In_the_parent pid ->
       Unix.close to_child_r ;
       Unix.close updates_w ;
       {pid; down_pipe= Unix.out_channel_of_descr to_child_w}
+
+
+(** Data marshalled to describe what a child spawned by [spawn_child] below must do. *)
+type ('work, 'result, 'final) child_data =
+  {slot: int; child_prologue: unit -> unit; f: 'work -> 'result option; epilogue: unit -> 'final}
+
+(** Spawn a new child and start it so that it is ready for work.
+
+    The child inherits [updates_w] to send updates up to the parent, and a new pipe is set up for
+    the parent to send instructions down to the child. *)
+let spawn_child ~child_prologue ~slot (_updates_r, updates_w) ~f ~epilogue =
+  let to_child_r, to_child_w = Unix.pipe () in
+  let orig_args = Sys.get_argv () in
+  let args =
+    (* Craft the command-line for the subprocesses: add --run-as-child <n> to the current one *)
+    match Array.to_list orig_args with
+    | [] ->
+        assert false (* always contain the name of the binary *)
+    | hd_args :: tl_args ->
+        let new_argl = hd_args :: "--run-as-child" :: string_of_int slot :: tl_args in
+        Array.of_list new_argl
+  in
+  let pid =
+    UnixLabels.create_process ~prog:orig_args.(0) ~args ~stdin:to_child_r ~stdout:updates_w
+      ~stderr:Unix.stderr
+  in
+  let down_pipe = Unix.out_channel_of_descr to_child_w in
+  Stdlib.set_binary_mode_out down_pipe true ;
+  (* Send the closure _after_ the child has been created, so that it may start reading
+     it, hence unblocking the parent if the closure is too big. The scary messages
+     warnings in the comments above ("LIMITATION") do not apply, because the child will
+     not use [really_read] to access the contents of the pipe. *)
+  Marshal.to_channel down_pipe {slot; f; child_prologue; epilogue} [Marshal.Closures] ;
+  let[@warning "-26"] to_child_r = Unix.close to_child_r in
+  {pid= Pid.of_int pid; down_pipe}
+
+
+let run_as_child () =
+  let updates_oc = Unix.out_channel_of_descr Unix.stdout in
+  (* Note: the documentation in the Unix module is lying on that point, and this call seems
+     to be required under Windows. *)
+  Stdlib.set_binary_mode_out updates_oc true ;
+  let orders_ic = Unix.in_channel_of_descr Unix.stdin in
+  (* Same remark as for [updates_oc]. *)
+  Stdlib.set_binary_mode_in orders_ic true ;
+  (* Get what we should do and who we are from our parent. Do NOT use [really_read] here,
+     as we want the child and the parent to dialogue if the closure is too big.
+  *)
+  let ({slot; f; child_prologue; epilogue} : _ child_data) = Marshal.from_channel orders_ic in
+  child slot ~child_prologue ~f ~updates_oc ~orders_ic ~epilogue
 
 
 let rec create_pipes n = if Int.equal n 0 then [] else Unix.pipe () :: create_pipes (n - 1)
@@ -428,10 +490,11 @@ let create :
  fun ~jobs ~child_prologue ~f ~child_epilogue ~tasks ->
   let task_bar = TaskBar.create ~jobs in
   let children_pipes = create_pipes jobs in
+  let make_child = if Config.fork_mode then fork_child else spawn_child in
   let slots =
     Array.init jobs ~f:(fun slot ->
         let child_pipe = List.nth_exn children_pipes slot in
-        fork_child ~child_prologue ~slot child_pipe ~f ~epilogue:child_epilogue )
+        make_child ~child_prologue ~slot child_pipe ~f ~epilogue:child_epilogue )
   in
   ProcessPoolState.has_running_children := true ;
   Epilogues.register ~description:"Wait children processes exit" ~f:(fun () ->

--- a/infer/src/base/ProcessPool.mli
+++ b/infer/src/base/ProcessPool.mli
@@ -65,3 +65,8 @@ val create :
 val run : (_, 'final, 'result) t -> 'final option Array.t
 (** use the processes in the given process pool to run all the given tasks in parallel and return
     the results of the epilogues *)
+
+val run_as_child : unit -> never_returns
+(** run a child that has been started by [create_process], on platforms where [fork] is not
+    available. The child will take care of executing the proper code. Once it has started, it
+    receives order from the parent through [stdin], and send status updates through [stdout]. *)

--- a/infer/src/base/ProcessPoolState.ml
+++ b/infer/src/base/ProcessPoolState.ml
@@ -17,5 +17,3 @@ let pid = ref (lazy (Unix.getpid ()))
 let reset_pid () = pid := lazy (Unix.getpid ())
 
 let get_pid () = Lazy.force !pid
-
-let has_running_children = ref false

--- a/infer/src/base/ProcessPoolState.mli
+++ b/infer/src/base/ProcessPoolState.mli
@@ -17,5 +17,3 @@ val update_status : (Mtime.t -> string -> unit) ref
 val get_pid : unit -> Pid.t
 
 val reset_pid : unit -> unit
-
-val has_running_children : bool ref

--- a/infer/src/base/Serialization.ml
+++ b/infer/src/base/Serialization.ml
@@ -61,7 +61,7 @@ let create_serializer (key : Key.t) : 'a serializer =
     let filename = DB.filename_to_string fname in
     PerfEvent.(
       log (fun logger -> log_begin_event logger ~name:("writing " ^ key.name) ~categories:["io"] ())) ;
-    Utils.with_intermediate_temp_file_out filename ~f:(fun outc ->
+    Utils.with_intermediate_temp_file_out ~retry:true filename ~f:(fun outc ->
         Marshal.to_channel outc (key.key, version, data) [] ) ;
     PerfEvent.(log (fun logger -> log_end_event logger ()))
   in

--- a/infer/src/base/Utils.ml
+++ b/infer/src/base/Utils.ml
@@ -323,7 +323,10 @@ let realpath ?(warn_on_error = true) path =
 
 
 (* never closed *)
-let devnull = lazy (Unix.openfile "/dev/null" ~mode:[Unix.O_WRONLY])
+let devnull =
+  let file = if String.equal Sys.os_type "Win32" then "NUL" else "/dev/null" in
+  lazy (Unix.openfile file ~mode:[Unix.O_WRONLY])
+
 
 let suppress_stderr2 f2 x1 x2 =
   let restore_stderr src =

--- a/infer/src/base/Utils.mli
+++ b/infer/src/base/Utils.mli
@@ -66,7 +66,7 @@ val with_file_in : string -> f:(In_channel.t -> 'a) -> 'a
 
 val with_file_out : string -> f:(Out_channel.t -> 'a) -> 'a
 
-val with_intermediate_temp_file_out : string -> f:(Out_channel.t -> 'a) -> 'a
+val with_intermediate_temp_file_out : ?retry:bool -> string -> f:(Out_channel.t -> 'a) -> 'a
 (** like [with_file_out] but uses a fresh intermediate temporary file and rename to avoid
     write-write races *)
 

--- a/infer/src/base/dune
+++ b/infer/src/base/dune
@@ -9,8 +9,8 @@
  (flags
   (:standard -open Core -open IStdlib -open IStd -open ATDGenerated -open
     OpenSource))
- (libraries cmdliner core memtrace mtime.clock.os parmap re sqlite3 zip
-   ATDGenerated IStdlib OpenSource)
+ (libraries cmdliner core memtrace mtime.clock.os re sqlite3 zip ATDGenerated
+   IStdlib OpenSource)
  (preprocess
   (pps ppx_blob ppx_compare ppx_enumerate))
  (preprocessor_deps

--- a/infer/src/c_stubs/cpu_stubs.c
+++ b/infer/src/c_stubs/cpu_stubs.c
@@ -1,0 +1,36 @@
+#include <caml/mlvalues.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+CAMLprim value number_of_cpus (value unit)
+{
+  SYSTEM_INFO sysinfo;
+  GetSystemInfo (&sysinfo);
+  int numcores = (int) sysinfo.dwNumberOfProcessors;
+  return Val_int(numcores);
+}
+
+#elif defined (__linux__) || defined (__sun__) || defined (_AIX) \
+  || defined (__APPLE__) || defined (__FreeBSD__) || defined (__OpenBSD__) \
+  || defined (__DragonFly__) || defined (__NetBSD__)
+
+#include <unistd.h>
+
+CAMLprim value number_of_cpus (value unit)
+{
+  int numcores = (int) sysconf (_SC_NPROCESSORS_ONLN);
+  return Val_int(numcores);
+}
+
+#else
+
+/* Backup. Extremely unlikely given the platforms supported by Infer */
+
+CAMLprim value number_of_cpus (value unit)
+{
+  return Val_int(1);
+}
+
+#endif

--- a/infer/src/c_stubs/dune
+++ b/infer/src/c_stubs/dune
@@ -8,4 +8,4 @@
  (public_name infer.CStubs)
  (foreign_stubs
   (language c)
-  (names fnv64_hash)))
+  (names fnv64_hash cpu_stubs)))

--- a/infer/src/deadcode/dune.in
+++ b/infer/src/deadcode/dune.in
@@ -9,7 +9,7 @@
  (flags
   (:standard -w +60))
  (libraries javalib ANSITerminal async atdgen base base64 cmdliner core iter
-   memtrace mtime.clock.os ocamlgraph oUnit parmap re sawja sqlite3 str unix xmlm
+   memtrace mtime.clock.os ocamlgraph oUnit re sawja sqlite3 str unix xmlm
    yojson zarith zip CStubs)
  (modules All_infer_in_one_file)
  (preprocess

--- a/infer/src/dune.common.in
+++ b/infer/src/dune.common.in
@@ -15,6 +15,8 @@ let clang = is_yes "@BUILD_C_ANALYZERS@"
 
 let java = is_yes "@BUILD_JAVA_ANALYZERS@"
 
+let windows = is_yes "@WINDOWS_BUILD@"
+
 let facebook = is_yes "@IS_FACEBOOK_TREE@"
 
 let extra_cflags = if is_empty "@EXTRA_CFLAGS@" then [] else ["@EXTRA_CFLAGS@"]

--- a/infer/src/dune.in
+++ b/infer/src/dune.in
@@ -68,11 +68,13 @@ let infer_exe_stanza =
  (flags (:standard -open Core -open IStdlib -open IStd -open IBase -open IR -open Backend -open Integration -open Biabduction -open TestDeterminators -open ClangFrontend -open ASTLanguage %s -open JavaFrontend %s))
  (libraries %s core IStdlib IBase IR Backend Integration Biabduction TestDeterminators ClangFrontend ASTLanguage)
  (preprocess (pps ppx_compare))
+ (link_flags (:standard %s))
  (promote (until-clean) (into ../bin))
 )|}
     (if clang then "" else "-open ClangFrontendStubs")
     (if java then "" else "-open JavaFrontendStubs")
     extlib_if_java
+    (if windows then "-cclib -lgcc_s -cclib -lole32" else "")
 
 
 let inferunit_stanza =

--- a/infer/src/infer.ml
+++ b/infer/src/infer.ml
@@ -50,7 +50,7 @@ let setup () =
              ( Driver.is_analyze_mode driver_mode
              || Config.(
                   continue_capture || infer_is_clang || infer_is_javac || reactive_mode
-                  || incremental_analysis) )
+                  || incremental_analysis || Option.is_some run_as_child) )
       then ResultsDir.remove_results_dir () ;
       ResultsDir.create_results_dir () ;
       if
@@ -153,6 +153,9 @@ let () =
   if has_results_dir && Config.debug_mode && CLOpt.is_originator then (
     L.progress "Logs in %s@." (ResultsDir.get_path Logs) ;
     Option.iter Config.scuba_execution_id ~f:(fun id -> L.progress "Execution ID %Ld@." id) ) ;
+  if Option.is_some Config.run_as_child then (
+    InferAnalyze.register_active_checkers () ;
+    never_returns (ProcessPool.run_as_child ()) ) ;
   ( match Config.command with
   | _ when Config.test_determinator && not Config.process_clang_ast ->
       TestDeterminator.compute_and_emit_test_to_run ()

--- a/infer/src/istd/Escape.ml
+++ b/infer/src/istd/Escape.ml
@@ -100,6 +100,26 @@ let escape_path s =
   escape_map map s
 
 
+let escape_filename s =
+  let encode c = Some (Format.sprintf "%%%X" (Char.to_int c)) in
+  let map c =
+    match c with
+    | '/' ->
+        (* This character is fobidden on Windows and Unix *)
+        encode c
+    | '<' | '>' | ':' | '"' | '\\' | '|' | '?' | '*' | '\n' | '\r' | '\t' ->
+        (* All these characters are forbidden on Windows. See
+           https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names *)
+        if String.equal "Unix" Sys.os_type then None else encode c
+    | '\127' .. '\255' ->
+        (* Probably Unicode characters in filename. In doubt, encode *)
+        encode c
+    | _ ->
+        None
+  in
+  escape_map map s
+
+
 let escape_json s = escape_map (function '"' -> Some "\\\"" | '\\' -> Some "\\\\" | _ -> None) s
 
 let escape_double_quotes s = escape_map (function '"' -> Some "\\\"" | _ -> None) s

--- a/infer/src/istd/Escape.mli
+++ b/infer/src/istd/Escape.mli
@@ -31,3 +31,6 @@ val escape_in_single_quotes : string -> string
 
 val escape_shell : string -> string
 (** escape the string so it can be passed to the shell without remorse *)
+
+val escape_filename : string -> string
+(** escape the characters that cannot be used in filenames *)

--- a/opam
+++ b/opam
@@ -39,7 +39,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlgraph"
   "ounit" {>="2.0.5"}
-  "parmap" {>="1.0-rc8"}
   "ppx_blob"
   "ppx_compare" {>= "v0.14.0" & < "v0.15"}
   "ppx_deriving" {>="4.1"}

--- a/opam.locked
+++ b/opam.locked
@@ -82,7 +82,6 @@ depends: [
   "octavius" {= "1.2.2"}
   "ounit" {= "2.2.3"}
   "ounit2" {= "2.2.3"}
-  "parmap" {= "1.1.1"}
   "parsexp" {= "v0.14.0"}
   "ppx_assert" {= "v0.14.0"}
   "ppx_base" {= "v0.14.0"}


### PR DESCRIPTION
This PR implements nearly all that's required to have Win32 support of Infer. As a disclaimer, we (AdaCore) are only using the MinGW port. I cannot really say whether those commits help for a Cygwin or MSVC build. In any case, most of the new tests are for Win32, hence do not activate under Cygwin.

This branch is almost feature-complete. The only missing commit is the one replacing Core by Core_kernel. It is ready on our end, but needs a bit of cleanup before being sent here. In the meantime, all those commits should be ok independently, in particular under Linux.

The "meat" of the patch is the commit entitled "Reimplement tasking without the use of fork()". Everything else is also important at different levels, but significantly less so. Close seconds are the commits "Use mode O_SHARE_DELETE when opening files" and "Add a notion of retries to database serialization", as the current implementation of "atomic-rename for summaries" does not work well under Windows.
