### PR TITLE
Add support for correctly reading the 'TMPDIR' environment variable

### DIFF
--- a/facebook-clang-plugins/clang/setup.sh
+++ b/facebook-clang-plugins/clang/setup.sh
@@ -222,7 +222,7 @@ popd
 if [ -n "$CLANG_TMP_DIR" ]; then
     TMP=$CLANG_TMP_DIR
 else
-    TMP=`mktemp -d /tmp/clang-setup.XXXXXX`
+    TMP=`mktemp -d ${TMPDIR-/tmp}/clang-setup.XXXXXX`
 fi
 pushd "$TMP"
 


### PR DESCRIPTION
Infer's [`install-sh`](https://github.com/facebook/infer/blob/master/install-sh) knows to "correctly" read from the `TMPDIR` environment variable:

- https://github.com/facebook/infer/blob/master/install-sh#L327

However, this was not supported by `clang/setup.sh`.

I haven't overlooked the existence of `CLANG_TMP_DIR`, but I had (initially) set `TMPDIR` hoping Infer's build system would honour it (it didn't) -- consequently, I thought it would be useful for future users if Infer honoured this.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>