### PR TITLE
Adding a new line when pretty-printing a structured value

### DIFF
--- a/infer/src/IR/Struct.ml
+++ b/infer/src/IR/Struct.ml
@@ -87,7 +87,7 @@ let pp pe name f
      exported_obj_methods: {@[<v>%a@]}@,\
      annots: {@[<v>%a@]}@,\
      java_class_info: {@[<v>%a@]}@,\
-     dummy: %b@]@,"
+     dummy: %b@,@]"
     Typ.Name.pp name
     (seq (pp_field pe))
     fields


### PR DESCRIPTION
## Issue:

On `master`, it seems that there is a missing newline when Infer prints the `tenv` for a structure type:

```bash
avj@platypus /tmp/infer_bug$ cat test.c
typedef struct {
  int a;
} st1;

typedef struct {
  int b;
} st2;
avj@platypus /tmp/infer_bug$ infer --version
Infer version v1.0.0-55871dd28
Copyright 2009 - present Facebook. All Rights Reserved.
avj@platypus /tmp/infer_bug$ rm -rf infer-out && infer --debug run -P -- gcc -c test.c
Logs in /tmp/infer_bug/infer-out/logs
Capturing in make/cc mode...
Found 1 source file to analyze in /tmp/infer_bug/infer-out

  No issues found
avj@platypus /tmp/infer_bug$ grep -A1 "dummy" infer-out/captured/*/*.tenv.debug
dummy: falsestruct st1
fields: {
--
dummy: falsestruct st2
fields: {
--
dummy: falsestruct objc_class
fields: {}
```

(notice that `dummy: false` and `struct objc_class` are on the same line, with no spacing)

## Resolution

Their PR adds an explicit newline at the end of pretty-printing a structured value, such that it is formatted correctly in the `tenv`:

```bash
avj@platypus /tmp/infer_bug$ infer --version
Infer version v1.1.0-bb5a33506
Copyright 2009 - present Facebook. All Rights Reserved.
avj@platypus /tmp/infer_bug$ rm -rf infer-out && infer --debug run -P -- gcc -c test.c
Logs in /tmp/infer_bug/infer-out/logs
Capturing in make/cc mode...
Found 1 source file to analyze in /tmp/infer_bug/infer-out

  No issues found
avj@platypus /tmp/infer_bug$ grep -A1 "dummy" infer-out/captured/*/*.tenv.debug
dummy: false
struct st1
--
dummy: false
struct st2
--
dummy: false
struct objc_class
--
dummy: false
```

(*edit*: I forgot to build after committing; now with updated hash)

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>

