### PR TITLE
[pulse] Fixed a bug in `PulseBaseDomain.isograph_map`.

### DIFF
--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -112,13 +112,13 @@ let leq ~lhs ~rhs =
      &&
      match
        BaseDomain.isograph_map BaseDomain.empty_mapping
-         ~lhs:(rhs.pre :> BaseDomain.t)
-         ~rhs:(lhs.pre :> BaseDomain.t)
+         ~lhs:(lhs.pre :> BaseDomain.t)
+         ~rhs:(rhs.pre :> BaseDomain.t)
      with
      | NotIsomorphic ->
          false
      | IsomorphicUpTo foot_mapping ->
-         BaseDomain.is_isograph (BaseDomain.invert_map foot_mapping)
+         BaseDomain.is_isograph foot_mapping
            ~lhs:(lhs.post :> BaseDomain.t)
            ~rhs:(rhs.post :> BaseDomain.t)
 

--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -112,13 +112,13 @@ let leq ~lhs ~rhs =
      &&
      match
        BaseDomain.isograph_map BaseDomain.empty_mapping
-         ~lhs:(lhs.pre :> BaseDomain.t)
-         ~rhs:(rhs.pre :> BaseDomain.t)
+         ~lhs:(rhs.pre :> BaseDomain.t)
+         ~rhs:(lhs.pre :> BaseDomain.t)
      with
      | NotIsomorphic ->
          false
      | IsomorphicUpTo foot_mapping ->
-         BaseDomain.is_isograph foot_mapping
+         BaseDomain.is_isograph (BaseDomain.invert_map foot_mapping)
            ~lhs:(lhs.post :> BaseDomain.t)
            ~rhs:(rhs.post :> BaseDomain.t)
 

--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -112,8 +112,8 @@ let leq ~lhs ~rhs =
      &&
      match
        BaseDomain.isograph_map BaseDomain.empty_mapping
-         ~lhs:(rhs.pre :> BaseDomain.t)
-         ~rhs:(lhs.pre :> BaseDomain.t)
+         ~lhs:(lhs.pre :> BaseDomain.t)
+         ~rhs:(rhs.pre :> BaseDomain.t)
      with
      | NotIsomorphic ->
          false

--- a/infer/src/pulse/PulseBaseDomain.ml
+++ b/infer/src/pulse/PulseBaseDomain.ml
@@ -178,11 +178,6 @@ module GraphComparison = struct
 
   let is_isograph ~lhs ~rhs mapping =
     match isograph_map ~lhs ~rhs mapping with IsomorphicUpTo _ -> true | NotIsomorphic -> false
-
-  let invert_map mapping =
-    { rhs_to_lhs= mapping.lhs_to_rhs
-    ; lhs_to_rhs= mapping.rhs_to_lhs }
-
 end
 
 let pp fmt {heap; stack; attrs} =

--- a/infer/src/pulse/PulseBaseDomain.ml
+++ b/infer/src/pulse/PulseBaseDomain.ml
@@ -125,7 +125,7 @@ module GraphComparison = struct
             IsomorphicUpTo mapping
         | Some _, None | None, Some _ ->
             NotIsomorphic
-        | Some (edges_rhs, attrs_rhs), Some (edges_lhs, attrs_lhs) ->
+        | Some (edges_lhs, attrs_lhs), Some (edges_rhs, attrs_rhs) ->
             (* continue the comparison recursively on all edges and attributes *)
             if Attributes.equal attrs_rhs attrs_lhs then
               let bindings_lhs = Memory.Edges.bindings edges_lhs in

--- a/infer/src/pulse/PulseBaseDomain.ml
+++ b/infer/src/pulse/PulseBaseDomain.ml
@@ -46,6 +46,7 @@ let find_cell_opt addr {heap; attrs} =
     reachable from stack variables). *)
 module GraphComparison = struct
   module AddressMap = PrettyPrintable.MakePPMap (AbstractValue)
+  module AddressSet = AbstractValue.Set
 
   (** translation between the abstract values on the LHS and the ones on the RHS *)
   type mapping =
@@ -75,7 +76,7 @@ module GraphComparison = struct
           mapping ;
         `AliasingLHS
     | Some _addr_rhs (* [_addr_rhs = addr_rhs] *) ->
-        `AlreadyVisited
+        `AlreadyVisited mapping
     | None -> (
       (* ...and have we seen [addr_rhs] before?.. *)
       match AddressMap.find_opt addr_rhs mapping.rhs_to_lhs with
@@ -103,14 +104,16 @@ module GraphComparison = struct
 
   (** can we extend [mapping] so that the subgraph of [lhs] rooted at [addr_lhs] is isomorphic to
       the subgraph of [rhs] rooted at [addr_rhs]? *)
-  let rec isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping =
+  let rec isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping visited =
     L.d_printfln "%a<->%a@\n" AbstractValue.pp addr_lhs AbstractValue.pp addr_rhs ;
     match record_equal mapping ~addr_lhs ~addr_rhs with
-    | `AlreadyVisited ->
-        IsomorphicUpTo mapping
+    | `AlreadyVisited mapping when AddressSet.mem addr_lhs visited ->
+        (IsomorphicUpTo mapping, visited)
     | `AliasingRHS | `AliasingLHS ->
-        NotIsomorphic
+        (NotIsomorphic, visited)
+    | `AlreadyVisited mapping 
     | `NotAlreadyVisited mapping -> (
+        let visited = AddressSet.add addr_lhs visited in
         let get_non_empty_cell addr astate =
           find_cell_opt addr astate
           |> Option.filter ~f:(fun (edges, attrs) ->
@@ -122,59 +125,62 @@ module GraphComparison = struct
         let rhs_cell_opt = get_non_empty_cell addr_rhs rhs in
         match (lhs_cell_opt, rhs_cell_opt) with
         | None, None ->
-            IsomorphicUpTo mapping
+            (IsomorphicUpTo mapping, visited)
         | Some _, None | None, Some _ ->
-            NotIsomorphic
+            (NotIsomorphic, visited)
         | Some (edges_lhs, attrs_lhs), Some (edges_rhs, attrs_rhs) ->
             (* continue the comparison recursively on all edges and attributes *)
             if Attributes.equal attrs_rhs attrs_lhs then
               let bindings_lhs = Memory.Edges.bindings edges_lhs in
               let bindings_rhs = Memory.Edges.bindings edges_rhs in
-              isograph_map_edges ~lhs ~edges_lhs:bindings_lhs ~rhs ~edges_rhs:bindings_rhs mapping
-            else NotIsomorphic )
+              isograph_map_edges ~lhs ~edges_lhs:bindings_lhs ~rhs ~edges_rhs:bindings_rhs mapping visited
+            else (NotIsomorphic, visited) )
 
 
   (** check that the isograph relation can be extended for all edges *)
-  and isograph_map_edges ~lhs ~edges_lhs ~rhs ~edges_rhs mapping =
+  and isograph_map_edges ~lhs ~edges_lhs ~rhs ~edges_rhs mapping visited =
     match (edges_lhs, edges_rhs) with
     | [], [] ->
-        IsomorphicUpTo mapping
+        (IsomorphicUpTo mapping, visited)
     | (a_lhs, (addr_lhs, _trace_lhs)) :: edges_lhs, (a_rhs, (addr_rhs, _trace_rhs)) :: edges_rhs
       when Memory.Access.equal a_lhs a_rhs -> (
       (* check isograph relation from the destination addresses *)
-      match isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping with
-      | IsomorphicUpTo mapping ->
+      match isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping visited with
+      | (IsomorphicUpTo mapping, visited) ->
           (* ok: continue with the other edges *)
-          isograph_map_edges ~lhs ~edges_lhs ~rhs ~edges_rhs mapping
-      | NotIsomorphic ->
-          NotIsomorphic )
+          isograph_map_edges ~lhs ~edges_lhs ~rhs ~edges_rhs mapping visited
+      | (NotIsomorphic, visited) ->
+          (NotIsomorphic, visited) )
     | _ :: _, _ :: _ | [], _ :: _ | _ :: _, [] ->
-        NotIsomorphic
+        (NotIsomorphic, visited)
 
 
   (** check that the memory graph induced by the addresses in [lhs] reachable from the variables in
       [stack_lhs] is a isograph of the same graph in [rhs] starting from [stack_rhs], up to some
       [mapping] *)
-  let rec isograph_map_from_stack ~lhs ~stack_lhs ~rhs ~stack_rhs mapping =
+  let rec isograph_map_from_stack ~lhs ~stack_lhs ~rhs ~stack_rhs mapping visited =
     match (stack_lhs, stack_rhs) with
     | [], [] ->
-        IsomorphicUpTo mapping
+        (IsomorphicUpTo mapping, visited)
     | (var_lhs, (addr_lhs, _trace_lhs)) :: stack_lhs, (var_rhs, (addr_rhs, _trace_rhs)) :: stack_rhs
       when Var.equal var_lhs var_rhs -> (
-      match isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping with
-      | IsomorphicUpTo mapping ->
-          isograph_map_from_stack ~lhs ~stack_lhs ~rhs ~stack_rhs mapping
-      | NotIsomorphic ->
-          NotIsomorphic )
+      match isograph_map_from_address ~lhs ~addr_lhs ~rhs ~addr_rhs mapping visited with
+      | (IsomorphicUpTo mapping, visited) ->
+          isograph_map_from_stack ~lhs ~stack_lhs ~rhs ~stack_rhs mapping visited
+      | (NotIsomorphic, visited) ->
+          (NotIsomorphic, visited) )
     | _ :: _, _ :: _ | [], _ :: _ | _ :: _, [] ->
-        NotIsomorphic
+        (NotIsomorphic, visited)
 
 
-  let isograph_map ~lhs ~rhs mapping =
+  let isograph_map_internal ~lhs ~rhs mapping visited =
     let stack_lhs = Stack.bindings lhs.stack in
     let stack_rhs = Stack.bindings rhs.stack in
-    isograph_map_from_stack ~lhs ~rhs ~stack_lhs ~stack_rhs mapping
+    let (result, _) = isograph_map_from_stack ~lhs ~rhs ~stack_lhs ~stack_rhs mapping visited in
+    result
 
+  let isograph_map ~lhs ~rhs mapping =
+    isograph_map_internal ~lhs ~rhs mapping AddressSet.empty
 
   let is_isograph ~lhs ~rhs mapping =
     match isograph_map ~lhs ~rhs mapping with IsomorphicUpTo _ -> true | NotIsomorphic -> false

--- a/infer/src/pulse/PulseBaseDomain.ml
+++ b/infer/src/pulse/PulseBaseDomain.ml
@@ -178,6 +178,11 @@ module GraphComparison = struct
 
   let is_isograph ~lhs ~rhs mapping =
     match isograph_map ~lhs ~rhs mapping with IsomorphicUpTo _ -> true | NotIsomorphic -> false
+
+  let invert_map mapping =
+    { rhs_to_lhs= mapping.lhs_to_rhs
+    ; lhs_to_rhs= mapping.rhs_to_lhs }
+
 end
 
 let pp fmt {heap; stack; attrs} =

--- a/infer/src/pulse/PulseBaseDomain.mli
+++ b/infer/src/pulse/PulseBaseDomain.mli
@@ -35,6 +35,8 @@ val isograph_map : lhs:t -> rhs:t -> mapping -> isograph_relation
 
 val is_isograph : lhs:t -> rhs:t -> mapping -> bool
 
+val invert_map : mapping -> mapping
+
 val find_cell_opt : AbstractValue.t -> t -> cell option
 
 val pp : F.formatter -> t -> unit

--- a/infer/src/pulse/PulseBaseDomain.mli
+++ b/infer/src/pulse/PulseBaseDomain.mli
@@ -35,8 +35,6 @@ val isograph_map : lhs:t -> rhs:t -> mapping -> isograph_relation
 
 val is_isograph : lhs:t -> rhs:t -> mapping -> bool
 
-val invert_map : mapping -> mapping
-
 val find_cell_opt : AbstractValue.t -> t -> cell option
 
 val pp : F.formatter -> t -> unit


### PR DESCRIPTION
I report one issue of `PulseAbductiveDomain.leq` operator (again) and a patch for this issue. I found this issue from my project. Since I'm using pulse domains and abstract transfer functions in my own way, it is not clear whether this issue can actually happen during the original pulse analysis.

This fix has been tested only manually. Do you have any domain operator test code?

Issue
-----
Assume the following two abstract states `lhs` and `rhs`:
* lhs
```
post{ roots={ &foo=v11,
              &bar=v13 };
  mem  ={ v11 -> { * -> v14 },    // here
          v13 -> { * -> v14 };
  ... }
		  
pre[{ roots={ &foo=v11,
              &bar=v13 };
	  mem  ={ v11 -> { * -> v12 },
	          v13 -> { * -> v14 }
	  ... }]
```
* rhs
```
post{ roots={ &foo=v1,
              &bar=v3};
  mem  ={ v1 -> { * -> v2 },     // here
          v3 -> { * -> v4 } };
  ... }
		  
pre[{ roots={ &foo=v1,
              &bar=v3 };
	  mem  ={ v1 -> { * -> v2 },
	          v3 -> { * -> v4 } };
	  ... }]
```

These are the minimized version of two abstract states. Assume that the omitted parts (unsat, bo, citv, formula, ...) are equivalent in the above two abstract states.

`PulseAbductiveDomain.leq lhs rhs` must return `false` because `lhs.post.mem` is not isomorphic to `rhs.post.mem` (see the `// here`). But, currently, `leq` operator returns `true` because it omits validating the relations of memory cells designated by `v11` and `v1` in `post` memory (`{ * -> v14 }` and `{ * -> v2 }`). When `isograph_map` is called for `pre` memories, it creates mapping that includes `v11 <-> v1`. When `isograph_map` is called for `post` memories, the valiation of relation between `{ * -> v14 }` and `{ * -> v2 }` are omitted because `v11 <-> v1` is already in the mapping.

My solution is to add `visited` set to check whether a given relation has been validated or not.


More details
------------
 `PulseAbductiveDomain.leq` computes two steps to confirm whether the memory is isomorphic, for `pre` memories and `post` memories.

In the first step, it compares the `pre` memory graphs with an empty mapping:  https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseAbductiveDomain.ml#L114

The result mapping would be as follows:
```
v1 <-> v11
v2 <-> v12
v3 <-> v13
v4 <-> v14
```

Then, in the second step, it compares the `post` memory graphs with the result of the first evaluation `foot_mapping`: https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseAbductiveDomain.ml#L121

Then, when it compares the stack variable `foo` , it uses to `isograph_map_from_address` to check whether two addresses `v11` and `v1` has a proper mapping:  https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseBaseDomain.ml#L164

Then, it calls `record_equal` with `v11` and `v1`: https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseBaseDomain.ml#L108
At this point, in `mapping`, there is already `v1 <-> v11` computed from the previous comparison `pre` memory graphs. So, it will return `AlreadyVisited`: https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseBaseDomain.ml#L68

Then, it does not check relation of memory cells (`{ * -> v14 }` and `{ * -> v2 }`) because `v1` and `v11` is already visited: https://github.com/facebook/infer/blob/fdd051afb1820aea0003c690ececac42bd92d8a6/infer/src/pulse/PulseBaseDomain.ml#L110
