### PR TITLE
Fix clang plugin compile error in FileUtils.cpp

### DIFF
--- a/facebook-clang-plugins/libtooling/FileUtils.cpp
+++ b/facebook-clang-plugins/libtooling/FileUtils.cpp
@@ -41,7 +41,7 @@ std::string makeAbsolutePath(const std::string &currentWorkingDirectory,
 
   while (llvm::sys::path::has_parent_path(path)) {
     path = llvm::sys::path::parent_path(path).str();
-    const std::string &element(llvm::sys::path::filename(path));
+    const std::string &element(llvm::sys::path::filename(path).str());
     if (element == ".") {
       continue;
     }


### PR DESCRIPTION
I ran into this error while compiling:

```
[*ERROR**][48253] FileUtils.cpp: In function ‘std::string FileUtils::makeAbsolutePath(const string&, std::string)’:
[*ERROR**][48253] FileUtils.cpp:44:57: error: invalid initialization of reference of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} from expression of type ‘llvm::StringRef’
[*ERROR**][48253]    44 |     const std::string &element(llvm::sys::path::filename(path));
[*ERROR**][48253]       |                                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

The path element in FileUtils.cpp was attempted to be initialised from an `llvm::StringRef` directly, which doesn't appear to be a thing that is implemented anywhere. This PR simply dereferences the `StringRef` to an `std::string` with `str()`, which makes the compile error go away.

The complete compile error output is as follows:

```
[02:04:57][48253] Building clang plugin...
[*ERROR**][48253] *** ERROR 'Building clang plugin'
[*ERROR**][48253] *** command: ' make INTERACTIVE=1 -C /home/graham/infer/facebook-clang-plugins/libtooling all CC=gcc CXX=g++ CFLAGS=-g -O2 CXXFLAGS=-g -O2 CPP=gcc -E LDFLAGS= LIBS= LOCAL_CLANG=/home/graham/infer/facebook-clang-plugins/clang/install/bin/clang CLANG_PREFIX=/home/graham/infer/facebook-clang-plugins/clang/install CLANG_INCLUDES=/home/graham/infer/facebook-clang-plugins/clang/install/include SDKPATH= '
[*ERROR**][48253] *** CWD: '/home/graham/infer'
[*ERROR**][48253] *** stdout:
[*ERROR**][48253] make[2]: Entering directory '/home/graham/infer/facebook-clang-plugins/libtooling'
[*ERROR**][48253] g++ -g -O2 -std=c++14 -fPIC -g -I/home/graham/infer/facebook-clang-plugins/clang/install/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -Wno-uninitialized  -Wno-missing-field-initializers -Wno-vla-extension -Wno-c99-extensions -O3 -DNDEBUG -c ASTExporter.cpp -o build/ASTExporter.o
[*ERROR**][48253] g++ -g -O2 -std=c++14 -fPIC -g -I/home/graham/infer/facebook-clang-plugins/clang/install/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -Wno-uninitialized  -Wno-missing-field-initializers -Wno-vla-extension -Wno-c99-extensions -O3 -DNDEBUG -c SimplePluginASTAction.cpp -o build/SimplePluginASTAction.o
[*ERROR**][48253] g++ -g -O2 -std=c++14 -fPIC -g -I/home/graham/infer/facebook-clang-plugins/clang/install/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -Wno-uninitialized  -Wno-missing-field-initializers -Wno-vla-extension -Wno-c99-extensions -O3 -DNDEBUG -c FileUtils.cpp -o build/FileUtils.o
[*ERROR**][48253] g++ -g -O2 -std=c++14 -fPIC -g -I/home/graham/infer/facebook-clang-plugins/clang/install/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -fvisibility-inlines-hidden -fno-exceptions -fno-rtti -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -Wno-uninitialized  -Wno-missing-field-initializers -Wno-vla-extension -Wno-c99-extensions -O3 -DNDEBUG -c AttrParameterVectorStream.cpp -o build/AttrParameterVectorStream.o
[*ERROR**][48253] make[2]: Leaving directory '/home/graham/infer/facebook-clang-plugins/libtooling'
[*ERROR**][48253] *** stderr:
[*ERROR**][48253] In file included from /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/DeclVisitor.h:21,
[*ERROR**][48253]                  from ASTExporter.h:41,
[*ERROR**][48253]                  from ASTExporter.cpp:17:
[*ERROR**][48253] /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/DeclOpenMP.h:97:1: warning: multi-line comment [-Wcomment]
[*ERROR**][48253]    97 | /// #pragma omp declare reduction (foo : int,float : omp_out += omp_in) \
[*ERROR**][48253]       | ^
[*ERROR**][48253] In file included from ASTExporter.cpp:17:
[*ERROR**][48253] ASTExporter.h:4552: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
[*ERROR**][48253]  4552 | #pragma clang diagnostic push
[*ERROR**][48253]       |
[*ERROR**][48253] ASTExporter.h:4553: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
[*ERROR**][48253]  4553 | #pragma clang diagnostic ignored "-Wcast-qual"
[*ERROR**][48253]       |
[*ERROR**][48253] ASTExporter.h:4555: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
[*ERROR**][48253]  4555 | #pragma clang diagnostic pop
[*ERROR**][48253]       |
[*ERROR**][48253] FileUtils.cpp: In function ‘std::string FileUtils::makeAbsolutePath(const string&, std::string)’:
[*ERROR**][48253] FileUtils.cpp:44:57: error: invalid initialization of reference of type ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’} from expression of type ‘llvm::StringRef’
[*ERROR**][48253]    44 |     const std::string &element(llvm::sys::path::filename(path));
[*ERROR**][48253]       |                                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
[*ERROR**][48253] At global scope:
[*ERROR**][48253] cc1plus: warning: unrecognized command line option ‘-Wno-c99-extensions’
[*ERROR**][48253] cc1plus: warning: unrecognized command line option ‘-Wno-vla-extension’
[*ERROR**][48253] make[2]: *** [../Makefile.rules:7: build/FileUtils.o] Error 1
[*ERROR**][48253] make[2]: *** Waiting for unfinished jobs....
[*ERROR**][48253] In file included from ASTExporter.cpp:17:
[*ERROR**][48253] ASTExporter.h:71:7: warning: C++ designated initializers only available with ‘-std=c++2a’ or ‘-std=gnu++2a’ [-Wpedantic]
[*ERROR**][48253]    71 |       .useYojson = false,
[*ERROR**][48253]       |       ^
[*ERROR**][48253] ASTExporter.h:72:7: warning: C++ designated initializers only available with ‘-std=c++2a’ or ‘-std=gnu++2a’ [-Wpedantic]
[*ERROR**][48253]    72 |       .prettifyJson = true,
[*ERROR**][48253]       |       ^
[*ERROR**][48253] In file included from ASTExporter.cpp:17:
[*ERROR**][48253] ASTExporter.h: In instantiation of ‘void ASTLib::ASTExporter<ATDWriter>::VisitObjCAvailabilityCheckExpr(const clang::ObjCAvailabilityCheckExpr*) [with ATDWriter = ATDWriter::JsonWriter<llvm::raw_ostream>]’:
[*ERROR**][48253] /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/StmtNodes.inc:1161:1:   required from ‘RetTy clang::StmtVisitorBase<Ptr, ImplClass, RetTy, ParamTys>::Visit(typename Ptr<clang::Stmt>::type, ParamTys ...) [with Ptr = llvm::make_const_ptr; ImplClass = ASTLib::ASTExporter<ATDWriter::JsonWriter<llvm::raw_ostream> >; RetTy = void; ParamTys = {}; typename Ptr<clang::Stmt>::type = const clang::Stmt*]’
[*ERROR**][48253] ASTExporter.h:3089:52:   required from ‘void ASTLib::ASTExporter<ATDWriter>::dumpStmt(const clang::Stmt*) [with ATDWriter = ATDWriter::JsonWriter<llvm::raw_ostream>]’
[*ERROR**][48253] ASTExporter.h:3048:9:   required from ‘void ASTLib::ASTExporter<ATDWriter>::VisitBlockDecl(const clang::BlockDecl*) [with ATDWriter = ATDWriter::JsonWriter<llvm::raw_ostream>]’
[*ERROR**][48253] /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/DeclNodes.inc:29:1:   required from ‘RetTy clang::declvisitor::Base<Ptr, ImplClass, RetTy>::Visit(typename Ptr<clang::Decl>::type) [with Ptr = llvm::make_const_ptr; ImplClass = ASTLib::ASTExporter<ATDWriter::JsonWriter<llvm::raw_ostream> >; RetTy = void; typename Ptr<clang::Decl>::type = const clang::Decl*]’
[*ERROR**][48253] ASTExporter.h:1072:52:   required from ‘void ASTLib::ASTExporter<ATDWriter>::dumpDecl(const clang::Decl*) [with ATDWriter = ATDWriter::JsonWriter<llvm::raw_ostream>]’
[*ERROR**][48253] ASTExporter.h:5448:5:   required from ‘void ASTLib::ExporterASTConsumer<ATDWriter, ForceYojson>::HandleTranslationUnit(clang::ASTContext&) [with ATDWriter = ATDWriter::JsonWriter<llvm::raw_ostream>; bool ForceYojson = false]’
[*ERROR**][48253] ASTExporter.h:5445:16:   required from here
[*ERROR**][48253] ASTExporter.h:4554:36: warning: cast from type ‘const clang::ObjCAvailabilityCheckExpr*’ to type ‘clang::ObjCAvailabilityCheckExpr*’ casts away qualifiers [-Wcast-qual]
[*ERROR**][48253]  4554 |     ObjCAvailabilityCheckExpr *E = (ObjCAvailabilityCheckExpr *)Expr;
[*ERROR**][48253]       |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[*ERROR**][48253] ASTExporter.h: In instantiation of ‘void ASTLib::ASTExporter<ATDWriter>::VisitObjCAvailabilityCheckExpr(const clang::ObjCAvailabilityCheckExpr*) [with ATDWriter = ATDWriter::BiniouWriter<llvm::raw_ostream>]’:
[*ERROR**][48253] /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/StmtNodes.inc:1161:1:   required from ‘RetTy clang::StmtVisitorBase<Ptr, ImplClass, RetTy, ParamTys>::Visit(typename Ptr<clang::Stmt>::type, ParamTys ...) [with Ptr = llvm::make_const_ptr; ImplClass = ASTLib::ASTExporter<ATDWriter::BiniouWriter<llvm::raw_ostream> >; RetTy = void; ParamTys = {}; typename Ptr<clang::Stmt>::type = const clang::Stmt*]’
[*ERROR**][48253] ASTExporter.h:3089:52:   required from ‘void ASTLib::ASTExporter<ATDWriter>::dumpStmt(const clang::Stmt*) [with ATDWriter = ATDWriter::BiniouWriter<llvm::raw_ostream>]’
[*ERROR**][48253] ASTExporter.h:3048:9:   required from ‘void ASTLib::ASTExporter<ATDWriter>::VisitBlockDecl(const clang::BlockDecl*) [with ATDWriter = ATDWriter::BiniouWriter<llvm::raw_ostream>]’
[*ERROR**][48253] /home/graham/infer/facebook-clang-plugins/clang/install/include/clang/AST/DeclNodes.inc:29:1:   required from ‘RetTy clang::declvisitor::Base<Ptr, ImplClass, RetTy>::Visit(typename Ptr<clang::Decl>::type) [with Ptr = llvm::make_const_ptr; ImplClass = ASTLib::ASTExporter<ATDWriter::BiniouWriter<llvm::raw_ostream> >; RetTy = void; typename Ptr<clang::Decl>::type = const clang::Decl*]’
[*ERROR**][48253] ASTExporter.h:1072:52:   required from ‘void ASTLib::ASTExporter<ATDWriter>::dumpDecl(const clang::Decl*) [with ATDWriter = ATDWriter::BiniouWriter<llvm::raw_ostream>]’
[*ERROR**][48253] ASTExporter.h:5448:5:   required from ‘void ASTLib::ExporterASTConsumer<ATDWriter, ForceYojson>::HandleTranslationUnit(clang::ASTContext&) [with ATDWriter = ATDWriter::BiniouWriter<llvm::raw_ostream>; bool ForceYojson = true]’
[*ERROR**][48253] ASTExporter.h:5445:16:   required from here
[*ERROR**][48253] ASTExporter.h:4554:36: warning: cast from type ‘const clang::ObjCAvailabilityCheckExpr*’ to type ‘clang::ObjCAvailabilityCheckExpr*’ casts away qualifiers [-Wcast-qual]
[*ERROR**][48253] cc1plus: warning: unrecognized command line option ‘-Wno-c99-extensions’
[*ERROR**][48253] cc1plus: warning: unrecognized command line option ‘-Wno-vla-extension’
make[1]: *** [Makefile:415: clang_plugin] Error 2
make[1]: Leaving directory '/home/graham/infer'
make: *** [Makefile:389: opt] Error 2

  compilation failure; you can try running

    make clean
    './build-infer.sh' clang
```