### PR TITLE
Forward type to implicit casts if part_of_explicit_cast

### DIFF
--- a/facebook-clang-plugins/clang-ocaml/clang_ast_proj.ml.p
+++ b/facebook-clang-plugins/clang-ocaml/clang_ast_proj.ml.p
@@ -218,6 +218,7 @@ let get_cast_kind = function
 #define ABSTRACT_STMT(TYPE)
 #define CASTEXPR(Type, Base) | Type (_, _, _, cast_expr_info)
 #define EXPLICITCASTEXPR(Type, Base) | Type (_, _, _, cast_expr_info, _)
+#define IMPLICITCASTEXPR(Type, Base) | Type (_, _, _, cast_expr_info, _)
 #define CXXNAMEDCASTEXPR(Type, Base) | Type (_, _, _, cast_expr_info, _, _)
 #define OBJCBRIDGEDCASTEXPR(Type, Base) | Type (_, _, _, cast_expr_info, _, _)
 #include<clang/AST/StmtNodes.inc>

--- a/facebook-clang-plugins/libtooling/ASTExporter.h
+++ b/facebook-clang-plugins/libtooling/ASTExporter.h
@@ -390,6 +390,7 @@ class ASTExporter : public ConstDeclVisitor<ASTExporter<ATDWriter>>,
   DECLARE_VISITOR(Expr)
   DECLARE_VISITOR(CastExpr)
   DECLARE_VISITOR(ExplicitCastExpr)
+  DECLARE_VISITOR(ImplicitCastExpr)
   DECLARE_VISITOR(DeclRefExpr)
   DECLARE_VISITOR(PredefinedExpr)
   DECLARE_VISITOR(CharacterLiteral)
@@ -3393,6 +3394,18 @@ void ASTExporter<ATDWriter>::VisitExplicitCastExpr(
     const ExplicitCastExpr *Node) {
   VisitCastExpr(Node);
   dumpQualType(Node->getTypeAsWritten());
+}
+
+template <class ATDWriter>
+int ASTExporter<ATDWriter>::ImplicitCastExprTupleSize() {
+  return CastExprTupleSize() + 1;
+}
+//@atd #define implicit_cast_expr_tuple cast_expr_tuple * bool
+template <class ATDWriter>
+void ASTExporter<ATDWriter>::VisitImplicitCastExpr(
+    const ImplicitCastExpr *Node) {
+  VisitCastExpr(Node);
+  OF.emitBoolean(Node->isPartOfExplicitCast());
 }
 
 template <class ATDWriter>

--- a/infer/src/al/AL.ml
+++ b/infer/src/al/AL.ml
@@ -102,7 +102,7 @@ let rec get_responds_to_selector stmt =
   | BinaryOperator (_, [stmt1; stmt2], _, bo_info)
     when PolyVariantEqual.( = ) bo_info.Clang_ast_t.boi_kind `LAnd ->
       List.append (get_responds_to_selector stmt1) (get_responds_to_selector stmt2)
-  | ImplicitCastExpr (_, [stmt], _, _)
+  | ImplicitCastExpr (_, [stmt], _, _, _)
   | ParenExpr (_, [stmt], _)
   | ExprWithCleanups (_, [stmt], _, _) ->
       get_responds_to_selector stmt
@@ -120,7 +120,7 @@ let rec is_core_foundation_version_number stmt =
         String.equal name_info.ni_name "kCFCoreFoundationVersionNumber"
     | None ->
         false )
-  | ImplicitCastExpr (_, [stmt], _, _) ->
+  | ImplicitCastExpr (_, [stmt], _, _, _) ->
       is_core_foundation_version_number stmt
   | _ ->
       false
@@ -133,7 +133,7 @@ let rec current_os_version_constant stmt =
       CiOSVersionNumbers.version_of number
   | IntegerLiteral (_, _, _, info) ->
       CiOSVersionNumbers.version_of info.ili_value
-  | ImplicitCastExpr (_, [stmt], _, _) ->
+  | ImplicitCastExpr (_, [stmt], _, _, _) ->
       current_os_version_constant stmt
   | _ ->
       None
@@ -153,7 +153,7 @@ let rec get_current_os_version stmt =
   | BinaryOperator (_, [stmt1; stmt2], _, bo_info)
     when PolyVariantEqual.( = ) bo_info.Clang_ast_t.boi_kind `LAnd ->
       List.append (get_current_os_version stmt1) (get_current_os_version stmt2)
-  | ImplicitCastExpr (_, [stmt], _, _)
+  | ImplicitCastExpr (_, [stmt], _, _, _)
   | ParenExpr (_, [stmt], _)
   | ExprWithCleanups (_, [stmt], _, _) ->
       get_current_os_version stmt
@@ -166,7 +166,7 @@ let rec get_ios_available_version stmt =
   match stmt with
   | ObjCAvailabilityCheckExpr (_, _, _, oacei) ->
       oacei.oacei_version
-  | ImplicitCastExpr (_, [stmt], _, _)
+  | ImplicitCastExpr (_, [stmt], _, _, _)
   | ParenExpr (_, [stmt], _)
   | ExprWithCleanups (_, [stmt], _, _) ->
       get_ios_available_version stmt

--- a/infer/src/al/cPredicates.ml
+++ b/infer/src/al/cPredicates.ml
@@ -418,7 +418,7 @@ let objc_message_receiver context an =
               CAst_utils.qual_type_to_objc_interface omdi.omdi_result_type
           | _ ->
               None )
-        | PseudoObjectExpr (_, _, ei) | ImplicitCastExpr (_, _, ei, _) | ParenExpr (_, _, ei) ->
+        | PseudoObjectExpr (_, _, ei) | ImplicitCastExpr (_, _, ei, _, _) | ParenExpr (_, _, ei) ->
             CAst_utils.qual_type_to_objc_interface ei.ei_qual_type
         | _ ->
             None )
@@ -1340,7 +1340,7 @@ let rec get_decl_attributes an =
   match an with
   | Stmt (CallExpr (_, func :: _, _)) ->
       get_decl_attributes (Stmt func)
-  | Stmt (ImplicitCastExpr (_, [stmt], _, _)) ->
+  | Stmt (ImplicitCastExpr (_, [stmt], _, _, _)) ->
       get_decl_attributes (Stmt stmt)
   | Stmt (DeclRefExpr (_, _, _, drti)) -> (
     match CAst_utils.get_decl_opt_with_decl_ref_opt drti.drti_decl_ref with
@@ -1362,7 +1362,7 @@ let rec get_decl_attributes_for_callexpr_param an =
   match an with
   | Stmt (CallExpr (_, func :: _, _)) ->
       get_decl_attributes_for_callexpr_param (Stmt func)
-  | Stmt (ImplicitCastExpr (_, [stmt], _, _)) ->
+  | Stmt (ImplicitCastExpr (_, [stmt], _, _, _)) ->
       get_decl_attributes_for_callexpr_param (Stmt stmt)
   | Stmt (DeclRefExpr (si, _, _, drti)) -> (
       L.debug Linters Verbose "#####POINTER LOOP UP: '%i'@\n" si.si_pointer ;

--- a/infer/src/al/ctl_parser_types.ml
+++ b/infer/src/al/ctl_parser_types.ml
@@ -45,7 +45,7 @@ let rec ast_node_name an =
         ast_node_name (Stmt stmt)
     | None ->
         "" )
-  | Stmt (ImplicitCastExpr (_, [stmt], _, _))
+  | Stmt (ImplicitCastExpr (_, [stmt], _, _, _))
   | Stmt (PseudoObjectExpr (_, stmt :: _, _))
   | Stmt (ParenExpr (_, [stmt], _)) ->
       ast_node_name (Stmt stmt)

--- a/infer/src/clang/ast_expressions.ml
+++ b/infer/src/clang/ast_expressions.ml
@@ -123,7 +123,7 @@ let create_implicit_cast_expr stmt_info stmts typ cast_kind =
     {Clang_ast_t.ei_qual_type= typ; ei_value_kind= `RValue; ei_object_kind= `Ordinary}
   in
   let cast_expr_info = {Clang_ast_t.cei_cast_kind= cast_kind; cei_base_path= []} in
-  Clang_ast_t.ImplicitCastExpr (stmt_info, stmts, expr_info, cast_expr_info)
+  Clang_ast_t.ImplicitCastExpr (stmt_info, stmts, expr_info, cast_expr_info, false)
 
 
 let create_nil stmt_info =

--- a/infer/src/clang/cTrans.ml
+++ b/infer/src/clang/cTrans.ml
@@ -73,7 +73,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
     | BlockExpr _ ->
         true
     (* the block can be wrapped in ExprWithCleanups  or ImplicitCastExpr*)
-    | ImplicitCastExpr (_, [s'], _, _) | ExprWithCleanups (_, [s'], _, _) ->
+    | ImplicitCastExpr (_, [s'], _, _, _) | ExprWithCleanups (_, [s'], _, _) ->
         is_block_expr s'
     | _ ->
         false
@@ -81,7 +81,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
 
   let objc_exp_of_type_block fun_exp_stmt =
     match fun_exp_stmt with
-    | Clang_ast_t.ImplicitCastExpr (_, _, ei, _)
+    | Clang_ast_t.ImplicitCastExpr (_, _, ei, _, _)
       when CType.is_block_type ei.Clang_ast_t.ei_qual_type ->
         true
     | _ ->
@@ -1003,7 +1003,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
       CType_decl.qual_type_to_sil_type context.CContext.tenv expr_info.Clang_ast_t.ei_qual_type
     in
     match (stmt_list, res_typ.desc, binary_operator_info.Clang_ast_t.boi_kind) with
-    | ( [s1; Clang_ast_t.ImplicitCastExpr (_, [s2], _, _)]
+    | ( [s1; Clang_ast_t.ImplicitCastExpr (_, [s2], _, _, _)]
       , Tstruct (CStruct _ as struct_name)
       , `Assign ) ->
         let res_trans_e1, res_trans_e2 =
@@ -1081,7 +1081,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
               true
           | UnaryOperator (_, stmts, _, _)
           | BinaryOperator (_, stmts, _, _)
-          | ImplicitCastExpr (_, stmts, _, _)
+          | ImplicitCastExpr (_, stmts, _, _, _)
           | ParenExpr (_, stmts, _) ->
               List.exists stmts ~f:is_complex_rhs
           | _ ->
@@ -3005,8 +3005,8 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
       let instruction' = exec_with_glvalue_as_reference instruction in
       let init_expr =
         match init_expr with
-        | Clang_ast_t.ImplicitCastExpr (_, [init_expr], _, _) when Option.is_some cstruct_name_opt
-          ->
+        | Clang_ast_t.ImplicitCastExpr (_, [init_expr], _, _, _)
+          when Option.is_some cstruct_name_opt ->
             init_expr
         | _ ->
             init_expr
@@ -3239,6 +3239,24 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
       extract_stmt_from_singleton stmt_list stmt_info.Clang_ast_t.si_source_range
         "In CastExpr There must be only one stmt defining the expression to be cast."
     in
+    let stmt =
+      match stmt with
+      | ImplicitCastExpr
+          ( inner_stmt_info
+          , inner_stmt_list
+          , inner_expr_info
+          , inner_cast_expr_info
+          , part_of_explicit_cast )
+        when part_of_explicit_cast ->
+          Clang_ast_t.ImplicitCastExpr
+            ( inner_stmt_info
+            , inner_stmt_list
+            , {inner_expr_info with ei_qual_type= expr_info.Clang_ast_t.ei_qual_type}
+            , inner_cast_expr_info
+            , part_of_explicit_cast )
+      | _ ->
+          stmt
+    in
     let cast_kind = cast_expr_info.Clang_ast_t.cei_cast_kind in
     let trans_state =
       match cast_kind with
@@ -3422,7 +3440,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
       |> mk_trans_result res_trans_stmt.return
     in
     match (stmt_list, context.CContext.return_param_typ) with
-    | ( ([Clang_ast_t.ImplicitCastExpr (_, [stmt], _, _)] | [stmt])
+    | ( ([Clang_ast_t.ImplicitCastExpr (_, [stmt], _, _, _)] | [stmt])
       , Some {desc= Tptr ({desc= Tstruct (CStruct _ as struct_name)}, _)} ) ->
         (* return (exp:struct); *)
         return_stmt stmt ~mk_ret_instrs:(fun ret_exp _root_typ ret_typ res_trans_stmt ->
@@ -4781,7 +4799,7 @@ module CTrans_funct (F : CModule_type.CFrontend) : CModule_type.CTranslation = s
         pseudoObjectExpr_trans trans_state stmt_list
     | UnaryExprOrTypeTraitExpr (_, _, _, unary_expr_or_type_trait_expr_info) ->
         unaryExprOrTypeTraitExpr_trans trans_state unary_expr_or_type_trait_expr_info
-    | ImplicitCastExpr (stmt_info, stmt_list, expr_info, cast_kind)
+    | ImplicitCastExpr (stmt_info, stmt_list, expr_info, cast_kind, _)
     | BuiltinBitCastExpr (stmt_info, stmt_list, expr_info, cast_kind, _)
     | CStyleCastExpr (stmt_info, stmt_list, expr_info, cast_kind, _)
     | CXXReinterpretCastExpr (stmt_info, stmt_list, expr_info, cast_kind, _, _)

--- a/infer/src/clang/cTrans_utils.ml
+++ b/infer/src/clang/cTrans_utils.ml
@@ -781,14 +781,15 @@ let should_remove_first_param {context= {tenv} as context; is_fst_arg_objc_insta
             , {drti_decl_ref= Some {dr_name= Some {ni_name= name}; dr_qual_type= Some qual_type}} )
         ]
       , _
-      , {cei_cast_kind= `LValueToRValue} )
+      , {cei_cast_kind= `LValueToRValue}
+      , _ )
     when is_fst_arg_objc_instance_method_call && String.equal name "self"
          && CType.is_class (CType_decl.qual_type_to_sil_type tenv qual_type) ->
       some_class_name stmt_info
   | ObjCMessageExpr
       ( _
       , [ ImplicitCastExpr
-            (_, [DeclRefExpr (stmt_info, _, _, _)], _, {cei_cast_kind= `LValueToRValue}) ]
+            (_, [DeclRefExpr (stmt_info, _, _, _)], _, {cei_cast_kind= `LValueToRValue}, _) ]
       , _
       , {omei_selector= selector} )
     when is_fst_arg_objc_instance_method_call && String.equal selector CFrontend_config.class_method

--- a/infer/tests/codetoanalyze/c/frontend/types/casts.c
+++ b/infer/tests/codetoanalyze/c/frontend/types/casts.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+void integral_cast() {
+    int a;
+    int b = ((char) a) + 2;
+}
+
+struct object {
+    int field;
+};
+
+void pointer_cast() {
+    void *obj;
+    int f = ((struct object *) obj)->field;
+}

--- a/infer/tests/codetoanalyze/c/frontend/types/casts.c.dot
+++ b/infer/tests/codetoanalyze/c/frontend/types/casts.c.dot
@@ -1,0 +1,25 @@
+/* @generated */
+digraph cfg {
+"integral_cast.d5430d978bb8b1ae1351542df63116f0_1" [label="1: Start integral_cast\nFormals: \nLocals:  b:int a:int \n  " color=yellow style=filled]
+	
+
+	 "integral_cast.d5430d978bb8b1ae1351542df63116f0_1" -> "integral_cast.d5430d978bb8b1ae1351542df63116f0_3" ;
+"integral_cast.d5430d978bb8b1ae1351542df63116f0_2" [label="2: Exit integral_cast \n  " color=yellow style=filled]
+	
+
+"integral_cast.d5430d978bb8b1ae1351542df63116f0_3" [label="3:  DeclStmt \n   VARIABLE_DECLARED(b:int); [line 10, column 5]\n  n$0=*&a:char [line 10, column 21]\n  *&b:int=(n$0 + 2) [line 10, column 5]\n " shape="box"]
+	
+
+	 "integral_cast.d5430d978bb8b1ae1351542df63116f0_3" -> "integral_cast.d5430d978bb8b1ae1351542df63116f0_2" ;
+"pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_1" [label="1: Start pointer_cast\nFormals: \nLocals:  f:int obj:void* \n  " color=yellow style=filled]
+	
+
+	 "pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_1" -> "pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_3" ;
+"pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_2" [label="2: Exit pointer_cast \n  " color=yellow style=filled]
+	
+
+"pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_3" [label="3:  DeclStmt \n   VARIABLE_DECLARED(f:int); [line 19, column 5]\n  n$0=*&obj:object* [line 19, column 32]\n  n$1=*n$0.field:int [line 19, column 13]\n  *&f:int=n$1 [line 19, column 5]\n " shape="box"]
+	
+
+	 "pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_3" -> "pointer_cast.3dc53891f7776356b25a5fbcd7d3c442_2" ;
+}

--- a/infer/tests/codetoanalyze/cpp/shared/types/casts.cpp.dot
+++ b/infer/tests/codetoanalyze/cpp/shared/types/casts.cpp.dot
@@ -18,7 +18,7 @@ digraph cfg {
 "stat_cast#12446126613472042601.03b0c783caaf8ed84eb6e909b7645c57_2" [label="2: Exit stat_cast \n  " color=yellow style=filled]
 	
 
-"stat_cast#12446126613472042601.03b0c783caaf8ed84eb6e909b7645c57_3" [label="3:  DeclStmt \n   VARIABLE_DECLARED(la:long long); [line 10, column 3]\n  n$0=*&a:int [line 10, column 41]\n  *&la:long long=n$0 [line 10, column 3]\n " shape="box"]
+"stat_cast#12446126613472042601.03b0c783caaf8ed84eb6e909b7645c57_3" [label="3:  DeclStmt \n   VARIABLE_DECLARED(la:long long); [line 10, column 3]\n  n$0=*&a:long long [line 10, column 41]\n  *&la:long long=n$0 [line 10, column 3]\n " shape="box"]
 	
 
 	 "stat_cast#12446126613472042601.03b0c783caaf8ed84eb6e909b7645c57_3" -> "stat_cast#12446126613472042601.03b0c783caaf8ed84eb6e909b7645c57_2" ;


### PR DESCRIPTION
Currently, casts are not added in clang AST translation except in a couple [special cases](https://github.com/facebook/infer/blob/85b8ad463cb72fc81edf04261b2aca31b8dfd467/infer/src/clang/cTrans_utils.ml#L556-L559), seemingly because adding them would [break existing checkers](https://github.com/facebook/infer/commit/1486a5f105fe131f93cd3ac48a6f23a0ba6d4ba7). This change fixes many of the casting cases that used to result in information loss without adding `Exp.Cast` expressions. When an `ImplicitCastExpr` has the `part_of_explicit_cast` bit set, it will be forwarded the type of its outer cast. This is particularly useful with `LValueToRValue` casts because it means the dereference assignment generated has the correct type.

Here are a couple cases where this prevents information loss (included as unit tests):

```c
void integral_cast() {
    int a;
    int b = ((char) a) + 2;
}

struct object {
    int field;
};

void pointer_cast() {
    void *obj;
    int f = ((struct object *) obj)->field;
}
```

Here are the clang ASTs for the casts:

```
|-ImplicitCastExpr 0x55e4e4986500 <col:13, col:22> 'int' <IntegralCast>
| `-ParenExpr 0x55e4e49864c0 <col:13, col:22> 'char'
|   `-CStyleCastExpr 0x55e4e4986498 <col:14, col:21> 'char' <IntegralCast>
|     `-ImplicitCastExpr 0x55e4e4986480 <col:21> 'int' <LValueToRValue> part_of_explicit_cast
|       `-DeclRefExpr 0x55e4e4986450 <col:21> 'int' lvalue Var 0x55e4e4986350 'a' 'int'
```

```
`-MemberExpr 0x55e4e49869a8 <col:13, col:38> 'int' lvalue ->field 0x55e4e4986630
  `-ParenExpr 0x55e4e4986988 <col:13, col:35> 'struct object *'
    `-CStyleCastExpr 0x55e4e4986960 <col:14, col:32> 'struct object *' <BitCast>
      `-ImplicitCastExpr 0x55e4e4986948 <col:32> 'void *' <LValueToRValue> part_of_explicit_cast
        `-DeclRefExpr 0x55e4e4986858 <col:32> 'void *' lvalue Var 0x55e4e4986758 'obj' 'void *'
```

Without this change, the `integral_cast` assignment has nothing indicating `a` got truncated to a `char`:

```
n$0=*&a:int
*&b:int=(n$0 + 2)
```

With this change, the assignment has the correct type:

```
n$0=*&a:char
*&b:int=(n$0 + 2)
```

The `pointer_cast` assignment without this change does not give any information about what type the field access is on:

```
n$0=*&obj:void*
n$1=*n$0.field:int
*&f:int=n$1
```

(edit: I realized that there actually is a `typ` stored in `Exp.Lfield`, but it only gives the struct type, not the pointer type, so it's still not ideal. For example, here you'd only have `void*` and `object`, and would have to reconstruct the `object*` yourself. So it's not strictly information loss, but this is much nicer.)

After this change, it has the correct type, allowing checkers to do things with that information:

```
n$0=*&obj:object*
n$1=*n$0.field:int
*&f:int=n$1
```