### PR TITLE
Add Infer# Support for Inference Between Type Expressions

### DIFF
--- a/infer/src/IR/StdTyp.ml
+++ b/infer/src/IR/StdTyp.ml
@@ -48,6 +48,8 @@ module Name = struct
     open Typ.Name.CSharp
 
     let system_string = from_string "System.String"
+
+    let system_object = from_string "System.Object"
   end
 
   module Objc = struct

--- a/infer/src/IR/StdTyp.mli
+++ b/infer/src/IR/StdTyp.mli
@@ -45,6 +45,8 @@ module Name : sig
 
   module CSharp : sig
     val system_string : t
+    
+    val system_object : t
   end
 
   module Objc : sig

--- a/infer/src/IR/Subtype.ml
+++ b/infer/src/IR/Subtype.ml
@@ -46,6 +46,8 @@ let is_root_class class_name =
   match class_name with
   | Typ.JavaClass _ ->
       Typ.Name.equal class_name StdTyp.Name.Java.java_lang_object
+  | Typ.CSharpClass _ ->
+      Typ.Name.equal class_name StdTyp.Name.CSharp.system_object
   | _ ->
       false
 

--- a/infer/src/IR/Typ.ml
+++ b/infer/src/IR/Typ.ml
@@ -512,6 +512,8 @@ module Name = struct
 
   module CSharp = struct
     let from_string name_str = CSharpClass (CSharpClassName.from_string name_str)
+
+    let is_class = function CSharpClass _ -> true | _ -> false
   end
 
   module Java = struct

--- a/infer/src/IR/Typ.mli
+++ b/infer/src/IR/Typ.mli
@@ -200,6 +200,8 @@ module Name : sig
 
   module CSharp : sig
     val from_string : string -> t
+
+    val is_class: t -> bool
   end
 
   module Java : sig

--- a/infer/src/biabduction/Prover.ml
+++ b/infer/src/biabduction/Prover.ml
@@ -44,6 +44,14 @@ let rec is_java_class tenv (typ : Typ.t) =
   | _ ->
       false
 
+let rec is_csharp_class tenv (typ : Typ.t) =
+  match typ.desc with
+  | Tstruct name ->
+      Typ.Name.CSharp.is_class name
+  | Tarray {elt= inner_typ} | Tptr (inner_typ, _) ->
+      is_csharp_class tenv inner_typ
+  | _ ->
+      false
 
 (** Negate an atom *)
 let atom_negate tenv (atom : Predicates.atom) : Predicates.atom =
@@ -1845,7 +1853,7 @@ let texp_imply tenv subs texp1 texp2 e1 calc_missing =
     | Exp.Sizeof {typ= typ1}, Exp.Sizeof {typ= typ2} -> (
       match (typ1.desc, typ2.desc) with
       | (Tstruct _ | Tarray _), (Tstruct _ | Tarray _) ->
-          is_java_class tenv typ1
+          (is_java_class tenv typ1 || is_csharp_class tenv typ1)
           || (Typ.is_cpp_class typ1 && Typ.is_cpp_class typ2)
           || (Typ.is_objc_class typ1 && Typ.is_objc_class typ2)
       | _ ->


### PR DESCRIPTION
This PR enables implications to be drawn between .NET types.  