### PR TITLE
Fix linguist tool configuration (exclude docs from stats)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-website/* linguist-documentation
+website/** linguist-documentation


### PR DESCRIPTION
With this change, language stats will be without html:

![image](https://user-images.githubusercontent.com/19646569/124871281-0ab86800-dfee-11eb-9551-7465394bc556.png)
