### PR TITLE
Patch missing 'limits' in facebook-clang-plugins #1407

### DIFF
--- a/facebook-clang-plugins/clang/src/benchmark_register.patch
+++ b/facebook-clang-plugins/clang/src/benchmark_register.patch
@@ -1,5 +1,5 @@
---- a/llvm-project/llvm/utils/benchmark/src/benchmark_register.h
-+++ b/llvm-project/llvm/utils/benchmark/src/benchmark_register.h
+--- a/llvm-project/libcxx/utils/google-benchmark/src/benchmark_register.h
++++ b/llvm-project/libcxx/utils/google-benchmark/src/benchmark_register.h
 @@ -1,6 +1,7 @@
  #ifndef BENCHMARK_REGISTER_H
  #define BENCHMARK_REGISTER_H


### PR DESCRIPTION
With the update to LLVM 12 (87a3d2708a0e2c09046ae5cc376d7e680b4995da) the patch I added in #1409 to avoid a missing `<limits>` now gets treated as an "accidentally reversed" patch. This is because upstream (== LLVM 12) now _includes_ the `#include` that #1409 added, which is why `patch` tries to remove `<limits>`:

```
+ for PATCH_FILE in ${CLANG_PREBUILD_PATCHES[*]}
+ patch --batch -p 1
patching file llvm-project/llvm/utils/benchmark/src/benchmark_register.h
Reversed (or previously applied) patch detected!  Assuming -R.
+ popd
```

In trying to resolve this issue I also noticed that there's also `libcxx/utils/google-benchmark/src/benchmark_register.h` has the same "original" problem (that is, it uses `std::numeric_limits` without `#include <limits>`). See: https://github.com/llvm/llvm-project/blob/llvmorg-12.0.1/libcxx/utils/google-benchmark/src/benchmark_register.h#L4

Therefore, this PR does two things:

1. It removes the patch against `llvm/utils/benchmark/src/benchmark_register.h` (as this file is now correct upstream)
2. It patches `libcxx/utils/google-benchmark/src/benchmark_register.h` to also include `<limits>` (as it doesn't do this upstream)

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>

