### PR TITLE
Use 'force' over 'batch' when applying patches

### DIFF
--- a/facebook-clang-plugins/clang/setup.sh
+++ b/facebook-clang-plugins/clang/setup.sh
@@ -217,7 +217,7 @@ fi
 # apply prebuild patch
 pushd "${SCRIPT_DIR}/src/download"
 for PATCH_FILE in ${CLANG_PREBUILD_PATCHES[*]}; do
-    "$PATCH" --batch -p 1 < "$PATCH_FILE"
+    "$PATCH" --force -p 1 < "$PATCH_FILE"
 done
 popd
 


### PR DESCRIPTION
## Note

This PR disables "permissively" running `patch` when patching LLVM; the behaviour of `clang/setup.sh` only changes when `infer`'s version of LLVM is updated. As such, **I fully expect this PR to not work in CI (until #1532 is in) as the whole point is that it *should* fail the build**,

## Description

As part of #1532 it was seen that `clang/setup.sh` used `--batch` when calling `patch`. The `--batch` option has the following description (from https://man7.org/linux/man-pages/man1/patch.1.html):

```
       -t  or  --batch
          Suppress questions like -f, but make some different
          assumptions: skip patches whose headers do not contain file
          names (the same as -f); skip patches for which the file has
          the wrong version for the Prereq: line in the patch; and
          assume that patches are reversed if they look like they are.
```

comparatively, `--force` has the following description:

```
       -f  or  --force
          Assume that the user knows exactly what he or she is doing,
          and do not ask any questions.  Skip patches whose headers do
          not say which file is to be patched; patch files even though
          they have the wrong version for the Prereq: line in the patch;
          and assume that patches are not reversed even if they look
          like they are.  This option does not suppress commentary; use
          -s for that.
```

So, importantly, the "big difference" between `-f` and `-t` is that batch "*assume[s] that patches are reversed if they look like they are*" -- this clearly isn't good when moving to later LLVM versions, as it means the `facebook-clang-plugins` patches can "undo" upstream changes if they're making the same change as upstream has now made.

By way of example (from #1532):

```
+ for PATCH_FILE in ${CLANG_PREBUILD_PATCHES[*]}
+ patch --batch -p 1
patching file llvm-project/llvm/utils/benchmark/src/benchmark_register.h
Reversed (or previously applied) patch detected!  Assuming -R.
+ popd
```

Therefore, this PR simply changes `clang/setup.sh` to use `--force` rather than `--batch`.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>