### PR TITLE
[pulse] Fix use of is_functional in unknown_call function

### DIFF
--- a/infer/src/pulse/PulseCallOperations.ml
+++ b/infer/src/pulse/PulseCallOperations.ml
@@ -70,13 +70,13 @@ let unknown_call tenv path call_loc (reason : CallEvent.t) ~ret ~actuals ~formal
     in
     let+ astate =
       match f with
-      | None ->
-          Ok astate
-      | Some f ->
+      | Some f when !is_functional ->
           PulseArithmetic.and_equal (AbstractValueOperand ret_val)
             (FunctionApplicationOperand
                {f; actuals= List.map ~f:(fun ((actual_val, _hist), _typ) -> actual_val) actuals} )
             astate
+      | _ ->
+          Ok astate
     in
     match reason with
     | SkippedKnownCall proc_name ->


### PR DESCRIPTION
is_functional in PulseCallOperations.unknown_call is set but never used.