### PR TITLE
Readme.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ cd docker/1.1.0/
 docker build -t infer .
 # mount the local examples directory inside the image
 # you can mount your project directory here instead
-docker run -it infer -v $PWD/../../examples:/infer-examples /bin/bash
+docker run -it -v $PWD/../../examples:/infer-examples infer /bin/bash
 # you should now be inside the docker container with a shell prompt, e.g.
 # "root@5c3b9af90d59:/# "
 cd /infer-examples/


### PR DESCRIPTION
Hey,

The docker options need to be given first in-order to activate the docker command. If option "-v" is specified after "infer" (i.e. container name), the option "-v" is passed as an entry point to the container.

Please see CONTRIBUTING.md for how to set up your development environment and run tests

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
