### PR TITLE
Detect whether DBWriter can actually be used

### DIFF
--- a/infer/src/base/DBWriter.ml
+++ b/infer/src/base/DBWriter.ml
@@ -363,8 +363,9 @@ module Server = struct
 
   let socket_exists () = in_results_dir ~f:(fun () -> Sys.file_exists_exn socket_name)
 
-  let server () =
-    L.debug Analysis Quiet "Sqlite write daemon: starting up@." ;
+  (* Error recuperation is done by attempting this function at module initialization time, and
+     not using DbWriter at all in case it fails. See {!can_use_socket} below. *)
+  let setup_socket () =
     if socket_exists () then L.die InternalError "Sqlite write daemon: socket already exists@." ;
     let socket = Unix.socket ~domain:socket_domain ~kind:Unix.SOCK_STREAM ~protocol:0 () in
     in_results_dir ~f:(fun () -> Unix.bind socket ~addr:socket_addr) ;
@@ -372,13 +373,30 @@ module Server = struct
        there are no rules about the implied behaviour though.  Here use optimistically
        the number of workers, though even that is a guess. *)
     Unix.listen socket ~backlog:Config.jobs ;
+    socket
+
+
+  let remove_socket socket =
+    in_results_dir ~f:(fun () ->
+        Unix.close socket ;
+        Unix.unlink socket_name )
+
+
+  (* Check whether we can create a socket to communicate with the asynchronous DBWriter process. *)
+  let can_use_socket () =
+    try
+      let socket = setup_socket () in
+      remove_socket socket ;
+      true
+    with _ -> false
+
+
+  let server () =
+    L.debug Analysis Quiet "Sqlite write daemon: starting up@." ;
+    let socket = setup_socket () in
     L.debug Analysis Quiet "Sqlite write daemon: set up complete, waiting for connections@." ;
-    let shutdown () =
-      in_results_dir ~f:(fun () ->
-          Unix.close socket ;
-          Unix.remove socket_name )
-    in
-    Exception.try_finally ~f:(fun () -> server_loop socket) ~finally:shutdown
+    let finally () = remove_socket socket in
+    Exception.try_finally ~f:(fun () -> server_loop socket) ~finally
 
 
   let send cmd =
@@ -419,15 +437,30 @@ module Server = struct
 end
 
 let use_daemon =
-  let is_windows = match Version.build_platform with Windows -> true | Linux | Darwin -> false in
-  Config.((not is_windows) && dbwriter && (not (buck || genrule_mode)) && jobs > 1)
+  lazy
+    (let is_windows =
+       match Version.build_platform with Windows -> true | Linux | Darwin -> false
+     in
+     Config.((not is_windows) && dbwriter && (not (buck || genrule_mode)) && jobs > 1)
+     &&
+     (* Only the main process should try detecting whether the socket can be created.
+        Otherwise, re-spawned Infer will try to create a socket on top of the existing one. *)
+     if Config.is_originator then (
+       let socket_ok = Server.can_use_socket () in
+       if not socket_ok then
+         L.user_warning
+           "Cannot setup the socket to communicate with the database daemon. Performance will be \
+            impacted. Do you have enough rights to create a Unix socket in directory '%s'?@."
+           Config.toplevel_results_dir ;
+       socket_ok )
+     else Server.socket_exists () )
 
 
-let perform cmd = if use_daemon then Server.send cmd else Command.execute cmd
+let perform cmd = if Lazy.force use_daemon then Server.send cmd else Command.execute cmd
 
 let start () = Server.start ()
 
-let stop () = Server.send Command.Terminate
+let stop () = try Server.send Command.Terminate with Unix.Unix_error _ -> ()
 
 let replace_attributes ~proc_uid ~proc_name ~attr_kind ~source_file ~proc_attributes ~cfg ~callees =
   perform

--- a/infer/src/base/DBWriter.mli
+++ b/infer/src/base/DBWriter.mli
@@ -8,7 +8,7 @@
 
 open! IStd
 
-val use_daemon : bool
+val use_daemon : bool Lazy.t
 (** indicates that there should be a daemon running *)
 
 val replace_attributes :

--- a/infer/src/infer.ml
+++ b/infer/src/infer.ml
@@ -28,7 +28,7 @@ let setup () =
   let db_start =
     let already_started = ref false in
     fun () ->
-      if (not !already_started) && Config.is_originator && DBWriter.use_daemon then (
+      if (not !already_started) && Config.is_originator && Lazy.force DBWriter.use_daemon then (
         DBWriter.start () ;
         Epilogues.register ~f:DBWriter.stop ~description:"Stop Sqlite write daemon" ;
         already_started := true )


### PR DESCRIPTION
... on systems where it is assumed available.

We have had customers under Linux with DBWriter related errors. Some
filesystems (e.g. ClearCase, or Vagrant synced folders) do not allow
creating a Unix domain socket on them. This patch tries to detect
whether sockets are supported, and falls back to --no-dbwriter
behavior when they are not.