### PR TITLE
Add no code flow flag for SARIF

### DIFF
--- a/infer/man/man1/infer-full.txt
+++ b/infer/man/man1/infer-full.txt
@@ -1244,6 +1244,11 @@ OPTIONS
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)           See also infer-run(1).
 
+       --no-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --sarif-codeflows)           See also infer-run(1).
+
        --scheduler { file | restart | callgraph }
            Specify the scheduler used for the analysis phase:           - file: schedule one job per file
            - callgraph: schedule one job per procedure, following the

--- a/infer/man/man1/infer-full.txt
+++ b/infer/man/man1/infer-full.txt
@@ -630,6 +630,11 @@ OPTIONS
            
            See also infer-report(1).
 
+       --drop-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --no-drop-sarif-codeflows)           See also infer-run(1).
+
        --dump-duplicate-symbols
            Activates: Dump all symbols with the same name that are defined in
            more than one file. (Conversely: --no-dump-duplicate-symbols)       
@@ -1243,11 +1248,6 @@ OPTIONS
            Activates: Output issues in SARIF (Static Analysis Results
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)           See also infer-run(1).
-
-       --no-sarif-codeflows
-           Activates: Output issues in SARIF (Static Analysis Results
-           Interchange Format) in infer-out/report.sarif without codeflows
-           (Conversely: --sarif-codeflows)           See also infer-run(1).
 
        --scheduler { file | restart | callgraph }
            Specify the scheduler used for the analysis phase:           - file: schedule one job per file

--- a/infer/man/man1/infer-run.txt
+++ b/infer/man/man1/infer-run.txt
@@ -138,6 +138,11 @@ OPTIONS
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)
 
+       --no-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --sarif-codeflows)
+
        --skip-analysis-in-path +regex
            Ignore files whose path matches a given regex (can be specified
            multiple times, but you must make sure each regex is properly

--- a/infer/man/man1/infer-run.txt
+++ b/infer/man/man1/infer-run.txt
@@ -65,6 +65,11 @@ OPTIONS
            Debug level for the linters. See --debug-level for accepted
            values.
 
+       --drop-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --no-drop-sarif-codeflows)
+
        --fail-on-issue
            Activates: Exit with error code 2 if Infer found something to
            report (Conversely: --no-fail-on-issue)
@@ -137,11 +142,6 @@ OPTIONS
            Activates: Output issues in SARIF (Static Analysis Results
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)
-
-       --no-sarif-codeflows
-           Activates: Output issues in SARIF (Static Analysis Results
-           Interchange Format) in infer-out/report.sarif without codeflows
-           (Conversely: --sarif-codeflows)
 
        --skip-analysis-in-path +regex
            Ignore files whose path matches a given regex (can be specified

--- a/infer/man/man1/infer.txt
+++ b/infer/man/man1/infer.txt
@@ -1244,6 +1244,11 @@ OPTIONS
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)           See also infer-run(1).
 
+       --no-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --sarif-codeflows)           See also infer-run(1).
+
        --scheduler { file | restart | callgraph }
            Specify the scheduler used for the analysis phase:           - file: schedule one job per file
            - callgraph: schedule one job per procedure, following the

--- a/infer/man/man1/infer.txt
+++ b/infer/man/man1/infer.txt
@@ -630,6 +630,11 @@ OPTIONS
            
            See also infer-report(1).
 
+       --drop-sarif-codeflows
+           Activates: Output issues in SARIF (Static Analysis Results
+           Interchange Format) in infer-out/report.sarif without codeflows
+           (Conversely: --no-drop-sarif-codeflows)           See also infer-run(1).
+
        --dump-duplicate-symbols
            Activates: Dump all symbols with the same name that are defined in
            more than one file. (Conversely: --no-dump-duplicate-symbols)       
@@ -1243,11 +1248,6 @@ OPTIONS
            Activates: Output issues in SARIF (Static Analysis Results
            Interchange Format) in infer-out/report.sarif (Conversely:
            --no-sarif)           See also infer-run(1).
-
-       --no-sarif-codeflows
-           Activates: Output issues in SARIF (Static Analysis Results
-           Interchange Format) in infer-out/report.sarif without codeflows
-           (Conversely: --sarif-codeflows)           See also infer-run(1).
 
        --scheduler { file | restart | callgraph }
            Specify the scheduler used for the analysis phase:           - file: schedule one job per file

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -2381,6 +2381,12 @@ and sarif =
     "Output issues in SARIF (Static Analysis Results Interchange Format) in infer-out/report.sarif"
 
 
+and no_sarif_codeflows =
+  CLOpt.mk_bool ~long:"no-sarif-codeflows" ~default:false
+    ~in_help:InferCommand.[(Run, manual_generic)]
+    "Output issues in SARIF (Static Analysis Results Interchange Format) in infer-out/report.sarif without codeflows"
+
+
 and scheduler =
   CLOpt.mk_symbol ~long:"scheduler" ~default:File ~eq:equal_scheduler
     ~in_help:InferCommand.[(Analyze, manual_generic)]
@@ -3557,6 +3563,8 @@ and reports_include_ml_loc = !reports_include_ml_loc
 and results_dir = !results_dir
 
 and sarif = !sarif
+
+and no_sarif_codeflows = !no_sarif_codeflows
 
 and scheduler = !scheduler
 

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -2381,8 +2381,8 @@ and sarif =
     "Output issues in SARIF (Static Analysis Results Interchange Format) in infer-out/report.sarif"
 
 
-and no_sarif_codeflows =
-  CLOpt.mk_bool ~long:"no-sarif-codeflows" ~default:false
+and drop_sarif_codeflows =
+  CLOpt.mk_bool ~long:"drop-sarif-codeflows" ~default:false
     ~in_help:InferCommand.[(Run, manual_generic)]
     "Output issues in SARIF (Static Analysis Results Interchange Format) in infer-out/report.sarif without codeflows"
 
@@ -3564,7 +3564,7 @@ and results_dir = !results_dir
 
 and sarif = !sarif
 
-and no_sarif_codeflows = !no_sarif_codeflows
+and drop_sarif_codeflows = !drop_sarif_codeflows
 
 and scheduler = !scheduler
 

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -608,6 +608,8 @@ val results_dir : string
 
 val sarif : bool
 
+val no_sarif_codeflows : bool
+
 val scheduler : scheduler
 
 val scuba_logging : bool

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -608,7 +608,7 @@ val results_dir : string
 
 val sarif : bool
 
-val no_sarif_codeflows : bool
+val drop_sarif_codeflows : bool
 
 val scheduler : scheduler
 

--- a/infer/src/integration/SarifReport.ml
+++ b/infer/src/integration/SarifReport.ml
@@ -114,7 +114,7 @@ let pp_jsonbug fmt {Jsonbug_t.file; severity; bug_type; qualifier; line; column;
   let thread_flow_locs = [{Sarifbug_j.locations= loc_trace_to_sarifbug_record bug_trace}] in
   let trace_list_length = List.length bug_trace in
   let thread_flow =
-    if not Config.no_sarif_codeflows && trace_list_length > 0 then Some [{Sarifbug_j.threadFlows= thread_flow_locs}] else None
+    if not Config.drop_sarif_codeflows && trace_list_length > 0 then Some [{Sarifbug_j.threadFlows= thread_flow_locs}] else None
   in
   let result =
     {Sarifbug_j.message; level; ruleId; codeFlows= thread_flow; locations= file_location_to_record}

--- a/infer/src/integration/SarifReport.ml
+++ b/infer/src/integration/SarifReport.ml
@@ -114,7 +114,7 @@ let pp_jsonbug fmt {Jsonbug_t.file; severity; bug_type; qualifier; line; column;
   let thread_flow_locs = [{Sarifbug_j.locations= loc_trace_to_sarifbug_record bug_trace}] in
   let trace_list_length = List.length bug_trace in
   let thread_flow =
-    if trace_list_length > 0 then Some [{Sarifbug_j.threadFlows= thread_flow_locs}] else None
+    if not Config.no_sarif_codeflows && trace_list_length > 0 then Some [{Sarifbug_j.threadFlows= thread_flow_locs}] else None
   in
   let result =
     {Sarifbug_j.message; level; ruleId; codeFlows= thread_flow; locations= file_location_to_record}


### PR DESCRIPTION
Hi,

As we mentioned in [this issue](https://github.com/facebook/infer/issues/1567), we added a new `no-sarif-codeflows` flag to avoid outputting bug traces in SARIF.  

Please ;let us know what you think :)