### PR TITLE
Move clang patching from clang/setup.sh to clang/src/prepare_clang_src.sh

### DIFF
--- a/facebook-clang-plugins/clang/setup.sh
+++ b/facebook-clang-plugins/clang/setup.sh
@@ -12,16 +12,8 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLANG_RELATIVE_SRC="src/download/llvm-project/llvm"
 CLANG_SRC="$SCRIPT_DIR/$CLANG_RELATIVE_SRC"
-CLANG_PREBUILD_PATCHES=(
-    "$SCRIPT_DIR/src/err_ret_local_block.patch"
-    "$SCRIPT_DIR/src/mangle_suppress_errors.patch"
-    "$SCRIPT_DIR/src/AArch64SVEACLETypes.patch"
-    "$SCRIPT_DIR/src/benchmark_register.patch"
-    "$SCRIPT_DIR/src/nsattributedstring.patch"
-)
 CLANG_PREFIX="$SCRIPT_DIR/install"
 CLANG_INSTALLED_VERSION_FILE="$SCRIPT_DIR/installed.version"
-PATCH=${PATCH:-patch}
 PATCHELF=${PATCHELF:-patchelf}
 PLATFORM_ENV=${PLATFORM_ENV:-}
 STRIP=${STRIP:-strip}
@@ -220,13 +212,6 @@ if [ ! -d "$CLANG_SRC" ]; then
     echo "Clang src (${CLANG_SRC}) missing, please run src/prepare_clang_src.sh"
     exit 1
 fi
-
-# apply prebuild patch
-pushd "${SCRIPT_DIR}/src/download"
-for PATCH_FILE in ${CLANG_PREBUILD_PATCHES[*]}; do
-    "$PATCH" --force -p 1 < "$PATCH_FILE"
-done
-popd
 
 if [ -n "$CLANG_TMP_DIR" ]; then
     TMP=$CLANG_TMP_DIR

--- a/facebook-clang-plugins/clang/src/prepare_clang_src.sh
+++ b/facebook-clang-plugins/clang/src/prepare_clang_src.sh
@@ -11,11 +11,19 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHASUM=${SHASUM:-shasum -a 256}
+PATCH=${PATCH:-patch}
 
 LLVM_VER="12.0.1"
 LLVM_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VER}/llvm-project-${LLVM_VER}.src.tar.xz"
 LLVM_SHA="129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e"
 LLVM_FILE="llvm-project.src.tar.xz"
+CLANG_PREBUILD_PATCHES=(
+    "$SCRIPT_DIR/err_ret_local_block.patch"
+    "$SCRIPT_DIR/mangle_suppress_errors.patch"
+    "$SCRIPT_DIR/AArch64SVEACLETypes.patch"
+    "$SCRIPT_DIR/benchmark_register.patch"
+    "$SCRIPT_DIR/nsattributedstring.patch"
+)
 
 mkdir -p "${SCRIPT_DIR}/download"
 pushd "${SCRIPT_DIR}/download" >/dev/null
@@ -29,5 +37,9 @@ rm -rf "llvm-project-${LLVM_VER}.src" "llvm-project"
 
 tar xf "${LLVM_FILE}"
 mv "llvm-project-${LLVM_VER}.src" "llvm-project"
+
+for PATCH_FILE in "${CLANG_PREBUILD_PATCHES[@]}"; do
+    "$PATCH" --force -p 1 < "$PATCH_FILE"
+done
 
 popd >/dev/null

--- a/facebook-clang-plugins/clang/src/prepare_clang_src.sh
+++ b/facebook-clang-plugins/clang/src/prepare_clang_src.sh
@@ -38,6 +38,7 @@ rm -rf "llvm-project-${LLVM_VER}.src" "llvm-project"
 tar xf "${LLVM_FILE}"
 mv "llvm-project-${LLVM_VER}.src" "llvm-project"
 
+# apply prebuild patch
 for PATCH_FILE in "${CLANG_PREBUILD_PATCHES[@]}"; do
     "$PATCH" --force -p 1 < "$PATCH_FILE"
 done


### PR DESCRIPTION
Since patching is not idempotent, it means cancelling and rerunning setup.sh will cause an error when the LLVM source code has already been patched.

Currently, if you cancel `facebook-clang-plugins/clang/setup.sh`, you have to either run `facebook-clang-plugins/clang/src/prepare_clang_src.sh` again, or comment out the patches from `facebook-clang-plugins/clang/setup.sh`.

This PR intends to improve this experience by making it safe to run either of the scripts multiple times in a row.