### PR TITLE
Fix CI for ocamlformat installation

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -115,7 +115,9 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Install ocamlformat
-        run: opam pin `cat opam/ocamlformat`
+        run: |
+          opam pin `cat opam/ocamlformat` --no-action
+          opam install ocamlformat odoc-parser.0.9.0
 
       - name: Test infer
         run: make test -k NDKBUILD=no


### PR DESCRIPTION
The version of ocamlformat we want is incompatible with odoc-parser.1.0.0
