### PR TITLE
Fix cache name in CI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -73,6 +73,10 @@ jobs:
         run: brew install automake jq ninja pkg-config lzlib zlib coreutils
         if: runner.os == 'macOS'
 
+      - name: Get OS version
+        uses: sersoft-gmbh/os-version-action@v1
+        id: os-version
+
       - name: Compute hash of clang installation
         id: clang-hash
         run: |
@@ -102,7 +106,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: opam-${{ runner.os }}-${{ hashFiles('opam/infer.opam.locked', 'opam/ocamlformat') }}-cache
+          key: opam-${{ matrix.os }}-${{steps.os-version.outputs.version}}-${{ hashFiles('opam/infer.opam.locked', 'opam/ocamlformat') }}
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1


### PR DESCRIPTION
runner.os is actually a very uninformative name: either 'Linux' or 'macOS'.
When ubuntu-latest or macOS-latest changes, the cached binaries become
incompatible with the new OS. But this is not detected by the cache
key we use. Thus, use 'os-version-action' to get this information.

Also, use 'matrix.os' instead of 'runner.os', which is slightly more
precise.  This changes nothing in practice, since Infer is tested on
only one version of each OS for the moment.
