### PR TITLE
Adding eli5 video

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -66,6 +66,29 @@ const poweredByItems = [
   { url: "https://wolfssl.com", name: "wolfSSL" },
 ];
 
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl margin-top--lg">
+      <div className="row">
+        <div className="col">
+          <h2>Check it out in the intro video</h2>
+          <div className={styles.ytVideo}>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/swrmPTJAGqQ"
+              title="Explain Like I'm 5: Infer"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
@@ -124,6 +147,7 @@ function Home() {
         </div>
       </header>
       <main>
+      <VideoContainer />
         {features && features.length && (
           <section className={styles.features}>
             <div className="container">


### PR DESCRIPTION
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Hermes home page](https://hermesengine.dev/) or in Docusaurus home page](https://docusaurus.io/)

## Test plan
This is how the video appears on the home page:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12485205/154197005-35fbe0e9-8f17-459a-a719-e34867d3483f.png">