### PR TITLE
Update banner to fit width of the screen

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -45,13 +45,13 @@ div[class^="announcementBarContent"] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
# Problem
The banner's font size as well as other styles are not adjusting to the screen.
This is because of the wrong style in media.

# Code
Should be `div[class^="announcementBarContent"]` instead of `.announcement` as the actual banner content class is `.announcementBarContent_6uhP.`

# Screenshots
![Screenshots](https://user-images.githubusercontent.com/78584173/166882195-43d0db18-b9d4-43be-82fc-10a4ccaba481.png)
