### PR TITLE
JsonReports.ml: fix --report-force-relative-path being ignored

### DIFF
--- a/infer/src/integration/JsonReports.ml
+++ b/infer/src/integration/JsonReports.ml
@@ -62,7 +62,7 @@ let loc_trace_to_jsonbug_record trace_list ekind =
   | _ ->
       let trace_item_to_record trace_item =
         { Jsonbug_j.level= trace_item.Errlog.lt_level
-        ; filename= SourceFile.to_string trace_item.Errlog.lt_loc.Location.file
+        ; filename= SourceFile.to_string ~force_relative:Config.report_force_relative_path trace_item.Errlog.lt_loc.Location.file
         ; line_number= trace_item.Errlog.lt_loc.Location.line
         ; column_number= trace_item.Errlog.lt_loc.Location.col
         ; description= trace_item.Errlog.lt_description }


### PR DESCRIPTION
This commit fixes an issue originally found through AdaCore's Ada
frontend for infer, but which is actually present for other frontends
too.

The issue is that infer will sometimes emit absolute paths in its JSON
report file despite --report-force-relative-path being present on the
command line. This issue can be reproduced with infer's C frontend like
this:

mkdir -p repro/child
cd repro/child
cat > ../file.c <<EOF
void main() {
  int A, B = 1;
  A = A + B;
}
EOF
cat > Makefile <<EOF
all: ../file.c
	gcc ../file.c
EOF
infer run --report-force-relative-path --quiet -- make
grep -o '"file[^"]*":"[^"]*"' infer-out/report.json

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
