### PR TITLE
[java] fix the source and target compatibility failures on the Maven tests

### DIFF
--- a/infer/tests/build_systems/codetoanalyze/mvn/app_with_infer_profile/pom.xml
+++ b/infer/tests/build_systems/codetoanalyze/mvn/app_with_infer_profile/pom.xml
@@ -26,4 +26,9 @@
       </build>
     </profile>
   </profiles>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>

--- a/infer/tests/build_systems/codetoanalyze/mvn/app_with_profiles/pom.xml
+++ b/infer/tests/build_systems/codetoanalyze/mvn/app_with_profiles/pom.xml
@@ -19,4 +19,9 @@
       </build>
     </profile>
   </profiles>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>

--- a/infer/tests/build_systems/codetoanalyze/mvn/app_with_submodules/module1/pom.xml
+++ b/infer/tests/build_systems/codetoanalyze/mvn/app_with_submodules/module1/pom.xml
@@ -6,4 +6,9 @@
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>module1</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>

--- a/infer/tests/build_systems/codetoanalyze/mvn/app_with_submodules/module2parent/module2/pom.xml
+++ b/infer/tests/build_systems/codetoanalyze/mvn/app_with_submodules/module2parent/module2/pom.xml
@@ -19,11 +19,8 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <encoding>UTF-8</encoding>
           <showWarnings>true</showWarnings>
-          <compilerArguments>
-            <Xlint:all/>
-            <Werror/>
-          </compilerArguments>
         </configuration>
       </plugin>
     </plugins>

--- a/infer/tests/build_systems/codetoanalyze/mvn/simple_app/pom.xml
+++ b/infer/tests/build_systems/codetoanalyze/mvn/simple_app/pom.xml
@@ -6,4 +6,9 @@
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>simple-app</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 </project>


### PR DESCRIPTION
Compiling the Maven tests was failing before these changes with the following errors:
```
$ mvn --version
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 11.0.16, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-47-generic", arch: "amd64", family: "unix"

$ cd infer/infer/tests/build_systems/codetoanalyze/mvn/simple_app

$ mvn clean compile
...
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
...
```

Specifying the source and target version in the Maven configuration file fixes the errors and the compilation works with Java 8, Java 11 and Java 18.

This does not affect the Maven integration tests and all the tests are passing locally with `make -j test`.