### PR TITLE
[pulse] Take into account reachable addresses from pre state

### DIFF
--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -1015,6 +1015,13 @@ let discard_unreachable_ ~for_summary ({pre; post} as astate) =
     PreDomain.filter_addr ~f:(fun address -> AbstractValue.Set.mem address pre_addresses) pre
   in
   let post_addresses = BaseDomain.reachable_addresses (post :> BaseDomain.t) in
+  let post_addresses =
+    (* Also include post addresses reachable from pre addresses *)
+    BaseDomain.reachable_addresses_from
+      (AbstractValue.Set.to_seq pre_addresses)
+      (post :> BaseDomain.t)
+      ~already_visited:post_addresses
+  in
   let always_reachable_addresses = get_all_addrs_marked_as_always_reachable astate in
   let always_reachable_trans_closure =
     BaseDomain.reachable_addresses_from always_reachable_addresses

--- a/infer/tests/codetoanalyze/cpp/pulse/instantiate_pre_addresses.cpp
+++ b/infer/tests/codetoanalyze/cpp/pulse/instantiate_pre_addresses.cpp
@@ -1,0 +1,68 @@
+struct rec {
+  int* x;
+};
+
+void foo(rec** ptr) {
+  (*ptr)->x = new int;
+  (*(*ptr)->x) = 24;
+  *ptr = new rec;
+}
+
+void no_leak_nullptr() {
+  rec* r1 = new rec{nullptr};
+  rec* r2 = r1;
+
+  foo(&r1);
+
+  if (*(r2->x) != 24) {
+    int* x = nullptr;
+    *x = 12;
+  }
+  *(r2->x) = 42;
+
+  delete r1;
+  delete r2->x;
+  delete r2;
+}
+
+struct list_item {
+  list_item* next;
+};
+
+struct list {
+  list_item* first;
+  list_item* last;
+};
+
+void append(list& l) {
+  list_item* new_cell = new list_item;
+  new_cell->next = nullptr;
+
+  if (l.last == nullptr) {
+    l.first = new_cell;
+  } else {
+    l.last->next = new_cell;
+  }
+
+  l.last = new_cell;
+}
+
+void delete_list(list& l) {
+  list_item* cell = l.first;
+  list_item* next_cell;
+
+  while (cell != nullptr) {
+    next_cell = cell->next;
+    delete cell;
+    cell = next_cell;
+  }
+}
+
+void no_leak() {
+  list l = {nullptr, nullptr};
+
+  append(l);
+  append(l);
+
+  delete_list(l);
+}


### PR DESCRIPTION
Pulse emits a false positive on the following cpp example:
```cpp
struct list_item {
  list_item* next;
};

struct list {
  list_item* first;
  list_item* last;
};

void append(list& l) {
  list_item* new_cell = new list_item;
  new_cell->next = nullptr;

  if (l.last == nullptr) {
    l.first = new_cell;
  } else {
    l.last->next = new_cell;
  }

  l.last = new_cell;
}

void delete_list(list& l) {
  list_item* cell = l.first;
  list_item* next_cell;

  while (cell != nullptr) {
    next_cell = cell->next;
    delete cell;
    cell = next_cell;
  }
}

void leak_false_positive() {
  list l = {nullptr, nullptr};

  append(l);
  append(l);

  delete_list(l);
}
```

The issue seems to be that when calling append for the second time, both l.first and l.last are pointing to the same value. When instantiating the summary Pulse misses to see that l.first->next and l.last should point to the same value.

The reason seems to be that Pulse is only following what is happening to l.last in the post, but not what is happening to the input value of l.last (which is l.first in the second call to append).

This PR fixes this issue, I also included more examples fixed by this commit.