### PR TITLE
BO: Add caller_procname to ModelEnv and remove proc_desc from OnDemandEnv.

### DIFF
--- a/infer/src/bufferoverrun/bufferOverrunAnalysis.ml
+++ b/infer/src/bufferoverrun/bufferOverrunAnalysis.ml
@@ -311,8 +311,9 @@ module TransferFunctions = struct
         Dom.Mem.add_unknown ret ~location mem
 
 
-  let call {interproc= {tenv}; get_summary; get_formals; oenv= {integer_type_widths}} node location
-      ((id, _) as ret) callee_pname args captured_vars mem =
+  let call
+      {interproc= {proc_desc= pdesc; tenv}; get_summary; get_formals; oenv= {integer_type_widths}}
+      node location ((id, _) as ret) callee_pname args captured_vars mem =
     let mem = Dom.Mem.add_stack_loc (Loc.of_id id) mem in
     let fun_arg_list =
       List.map args ~f:(fun (exp, typ) ->
@@ -322,8 +323,8 @@ module TransferFunctions = struct
     | Some {Models.exec} ->
         let model_env =
           let node_hash = CFG.Node.hash node in
-          BoUtils.ModelEnv.mk_model_env callee_pname ~node_hash location tenv integer_type_widths
-            get_summary
+          BoUtils.ModelEnv.mk_model_env callee_pname ~caller_pname:(Procdesc.get_proc_name pdesc)
+            ~node_hash location tenv integer_type_widths get_summary
         in
         exec model_env ~ret mem
     | None -> (

--- a/infer/src/bufferoverrun/bufferOverrunChecker.ml
+++ b/infer/src/bufferoverrun/bufferOverrunChecker.ml
@@ -271,7 +271,8 @@ let check_call get_checks_summary get_summary get_formals pname tenv integer_typ
   | Some {Models.check} ->
       let model_env =
         let node_hash = CFG.Node.hash node in
-        BoUtils.ModelEnv.mk_model_env pname ~node_hash location tenv integer_type_widths get_summary
+        BoUtils.ModelEnv.mk_model_env callee_pname ~caller_pname:pname ~node_hash location tenv
+          integer_type_widths get_summary
       in
       check model_env mem cond_set
   | None -> (

--- a/infer/src/bufferoverrun/bufferOverrunDomain.ml
+++ b/infer/src/bufferoverrun/bufferOverrunDomain.ml
@@ -2529,14 +2529,6 @@ module MemReach = struct
      | End ->
          add_cpp_iter_end_alias new_pvar m )
     |> Option.value ~default:m
-
-
-  let get_proc_desc m =
-    let oenv = GOption.value m.oenv in
-    oenv.proc_desc
-
-
-  let get_proc_name m = Procdesc.get_proc_name (get_proc_desc m)
 end
 
 module Mem = struct
@@ -2840,7 +2832,4 @@ module Mem = struct
 
   let propagate_cpp_iter_begin_or_end_alias ~new_pvar ~existing_pvar m =
     map m ~f:(MemReach.propagate_cpp_iter_begin_or_end_alias ~new_pvar ~existing_pvar)
-
-
-  let get_proc_name m = f_lift_default ~default:None (fun m -> Some (MemReach.get_proc_name m)) m
 end

--- a/infer/src/bufferoverrun/bufferOverrunDomain.mli
+++ b/infer/src/bufferoverrun/bufferOverrunDomain.mli
@@ -635,8 +635,6 @@ module Mem : sig
   val find_cpp_iterator_alias : Ident.t -> t -> (Pvar.t * Pvar.t * Binop.t) option
   (** Find the cpp iterator alias [ret_id -> {iter_lhs (binop) iter_rhs}] *)
 
-  val get_proc_name : GOption.some t0 -> Procname.t option
-
   val propagate_cpp_iter_begin_or_end_alias : new_pvar:Pvar.t -> existing_pvar:Pvar.t -> t -> t
   (** Propagate the being/end alias information from existing to new *)
 end

--- a/infer/src/bufferoverrun/bufferOverrunModels.ml
+++ b/infer/src/bufferoverrun/bufferOverrunModels.ml
@@ -115,7 +115,8 @@ let fgets str_exp num_exp =
 
 
 let malloc ~can_be_zero size_exp =
-  let exec ({pname; node_hash; location; tenv; integer_type_widths} as model_env) ~ret:(id, _) mem =
+  let exec ({pname; caller_pname; node_hash; location; tenv; integer_type_widths} as model_env)
+      ~ret:(id, _) mem =
     let size_exp = Prop.exp_normalize_noabs tenv Predicates.sub_empty size_exp in
     let typ, stride, length0, dyn_length = get_malloc_info size_exp in
     let length = Sem.eval integer_type_widths length0 mem in
@@ -127,8 +128,8 @@ let malloc ~can_be_zero size_exp =
     let offset, size = (Itv.zero, Dom.Val.get_itv length) in
     let represents_multiple_values = not (Itv.is_one size) in
     let allocsite =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-        ~dimension:1 ~path ~represents_multiple_values
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path
+        ~represents_multiple_values
     in
     let mem =
       if Config.bo_bottom_as_default then mem
@@ -152,8 +153,8 @@ let malloc ~can_be_zero size_exp =
     if Language.curr_language_is Java then
       let internal_arr =
         let allocsite =
-          Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-            ~dimension:1 ~path:None ~represents_multiple_values
+          Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+            ~represents_multiple_values
         in
         Dom.Val.of_java_array_alloc allocsite ~length:size ~traces
       in
@@ -323,16 +324,16 @@ let placement_new size_exp {exp= src_exp1; typ= t1} src_arg2_opt =
 
 
 let strndup src_exp length_exp =
-  let exec ({pname; node_hash; location; integer_type_widths} as model_env) ~ret:((id, _) as ret)
-      mem =
+  let exec ({pname; caller_pname; node_hash; location; integer_type_widths} as model_env)
+      ~ret:((id, _) as ret) mem =
     let v =
       let src_strlen = Dom.Mem.get_c_strlen (Sem.eval_locs src_exp mem) mem in
       let length = Sem.eval integer_type_widths length_exp mem in
       let size = Itv.incr (Itv.min_sem (Dom.Val.get_itv src_strlen) (Dom.Val.get_itv length)) in
       let allocsite =
         let represents_multiple_values = not (Itv.is_one size) in
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-          ~dimension:1 ~path:None ~represents_multiple_values
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+          ~represents_multiple_values
       in
       let traces =
         Trace.Set.join (Dom.Val.get_traces src_strlen) (Dom.Val.get_traces length)
@@ -415,7 +416,7 @@ let get_array_length array_exp =
 
 (* Clang only *)
 let set_array_length {exp; typ} length_exp =
-  let exec {pname; node_hash; location; integer_type_widths} ~ret:_ mem =
+  let exec {pname; caller_pname; node_hash; location; integer_type_widths} ~ret:_ mem =
     match (exp, typ) with
     | Exp.Lvar array_pvar, {Typ.desc= Typ.Tarray {stride}} ->
         let length = Sem.eval integer_type_widths length_exp mem in
@@ -425,8 +426,8 @@ let set_array_length {exp; typ} length_exp =
         let size = Dom.Val.get_itv length in
         let allocsite =
           let represents_multiple_values = not (Itv.is_one size) in
-          Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-            ~dimension:1 ~path ~represents_multiple_values
+          Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path
+            ~represents_multiple_values
         in
         let v = Dom.Val.of_c_array_alloc allocsite ~stride ~offset:Itv.zero ~size ~traces in
         Dom.Mem.add_stack (Loc.of_pvar array_pvar) v mem
@@ -654,13 +655,13 @@ module StdVector = struct
   (* The (3) constructor in https://en.cppreference.com/w/cpp/container/vector/vector *)
   let constructor_size elt_typ {exp= vec_exp; typ= vec_typ} size_exp =
     let {exec= malloc_exec; check} = malloc ~can_be_zero:true size_exp in
-    let exec ({pname; node_hash; integer_type_widths; location} as model_env) ~ret:((id, _) as ret)
-        mem =
+    let exec ({pname; caller_pname; node_hash; integer_type_widths; location} as model_env)
+        ~ret:((id, _) as ret) mem =
       let mem = malloc_exec model_env ~ret mem in
       let vec_locs = Sem.eval_locs vec_exp mem in
       let deref_of_vec =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-          ~dimension:1 ~path:None ~represents_multiple_values:false
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+          ~represents_multiple_values:false
         |> Loc.of_allocsite
       in
       let array_v =
@@ -815,7 +816,7 @@ end
 
 module StdBasicString = struct
   let constructor_from_char_ptr char_typ {exp= tgt_exp; typ= tgt_typ} src ~len_opt =
-    let exec ({pname; node_hash} as model_env) ~ret mem =
+    let exec ({pname; caller_pname; node_hash} as model_env) ~ret mem =
       let mem =
         Option.value_map len_opt ~default:mem ~f:(fun len ->
             let {exec= malloc_exec} = malloc ~can_be_zero:true len in
@@ -824,8 +825,8 @@ module StdBasicString = struct
       let tgt_locs = Sem.eval_locs tgt_exp mem in
       let tgt_deref =
         let allocsite =
-          Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-            ~dimension:1 ~path:None ~represents_multiple_values:false
+          Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+            ~represents_multiple_values:false
         in
         PowLoc.singleton (Loc.of_allocsite allocsite)
       in
@@ -876,11 +877,11 @@ module JavaInteger = struct
 
 
   let valueOf exp =
-    let exec {pname; node_hash; location; integer_type_widths} ~ret:(id, _) mem =
+    let exec {pname; caller_pname; node_hash; location; integer_type_widths} ~ret:(id, _) mem =
       let represents_multiple_values = false in
       let int_allocsite =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-          ~dimension:0 ~path:None ~represents_multiple_values
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:0 ~path:None
+          ~represents_multiple_values
       in
       let v = Sem.eval integer_type_widths exp mem in
       let int_loc = Loc.of_allocsite int_allocsite in
@@ -901,17 +902,17 @@ end
    - each time we add an element, we increase the length of the array
    - each time we delete an element, we decrease the length of the array *)
 module AbstractCollection (Lang : Lang) = struct
-  let create_collection {pname; node_hash; location} ~ret:(id, _) mem ~length =
+  let create_collection {pname; caller_pname; node_hash; location} ~ret:(id, _) mem ~length =
     let represents_multiple_values = true in
     let traces = Trace.(Set.singleton location ArrayDeclaration) in
     let coll_allocsite =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-        ~dimension:1 ~path:None ~represents_multiple_values
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+        ~represents_multiple_values
     in
     let internal_array =
       let allocsite =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-          ~dimension:1 ~path:None ~represents_multiple_values
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+          ~represents_multiple_values
       in
       Dom.Val.of_java_array_alloc allocsite ~length ~traces
     in
@@ -1172,13 +1173,13 @@ module Container = struct
 
 
   let constructor_size {exp= vec_exp} size_exp =
-    let exec ({pname; node_hash; integer_type_widths; location} as model_env) ~ret:((id, _) as ret)
-        mem =
+    let exec ({pname; caller_pname; node_hash; integer_type_widths; location} as model_env)
+        ~ret:((id, _) as ret) mem =
       let mem = (malloc ~can_be_zero:true size_exp).exec model_env ~ret mem in
       let vec_locs = Sem.eval_locs vec_exp mem in
       let deref_of_vec =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-          ~dimension:1 ~path:None ~represents_multiple_values:false
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+          ~represents_multiple_values:false
         |> Loc.of_allocsite
       in
       let array_v =
@@ -1207,23 +1208,23 @@ module NSCollection = struct
     let collection_internal_array_field = BufferOverrunField.objc_collection_internal_array
   end)
 
-  let create_collection {pname; node_hash; location; integer_type_widths} ~ret:(coll_id, _) mem
-      ~size_exp =
+  let create_collection {pname; caller_pname; node_hash; location; integer_type_widths}
+      ~ret:(coll_id, _) mem ~size_exp =
     let represents_multiple_values = true in
     let _, stride, length0, _ = get_malloc_info size_exp in
     let length = Sem.eval integer_type_widths length0 mem in
     let traces = Trace.(Set.add_elem location ArrayDeclaration) (Dom.Val.get_traces length) in
     let internal_array =
       let allocsite =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-          ~dimension:1 ~path:None ~represents_multiple_values
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+          ~represents_multiple_values
       in
       let offset, size = (Itv.zero, Dom.Val.get_itv length) in
       Dom.Val.of_c_array_alloc allocsite ~stride ~offset ~size ~traces
     in
     let coll_allocsite =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-        ~dimension:1 ~path:None ~represents_multiple_values
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+        ~represents_multiple_values
     in
     let coll_loc = Loc.of_allocsite coll_allocsite in
     let internal_array_loc =
@@ -1351,16 +1352,16 @@ module NSURL = struct
 end
 
 module JavaClass = struct
-  let decl_array {pname; node_hash; location} ~ret:(ret_id, _) length mem =
+  let decl_array {pname; caller_pname; node_hash; location} ~ret:(ret_id, _) length mem =
     let loc =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-        ~dimension:1 ~path:None ~represents_multiple_values:true
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+        ~represents_multiple_values:true
       |> Loc.of_allocsite
     in
     let arr_v =
       let allocsite =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-          ~dimension:1 ~path:None ~represents_multiple_values:true
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+          ~represents_multiple_values:true
       in
       let traces = Trace.(Set.singleton location ArrayDeclaration) in
       Dom.Val.of_java_array_alloc allocsite ~length ~traces
@@ -1465,7 +1466,7 @@ module JavaString = struct
   let get_length model_env exp mem = get_length_and_elem model_env exp mem |> fst
 
   let concat exp1 exp2 =
-    let exec ({pname; node_hash} as model_env) ~ret:(id, _) mem =
+    let exec ({pname; caller_pname; node_hash} as model_env) ~ret:(id, _) mem =
       let length_v, elem =
         let length1, elem1 = get_length_and_elem model_env exp1 mem in
         let length2, elem2 = get_length_and_elem model_env exp2 mem in
@@ -1473,13 +1474,13 @@ module JavaString = struct
       in
       let length, traces = (Dom.Val.get_itv length_v, Dom.Val.get_traces length_v) in
       let arr_loc =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-          ~dimension:1 ~path:None ~represents_multiple_values:false
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+          ~represents_multiple_values:false
         |> Loc.of_allocsite
       in
       let elem_alloc =
-        Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-          ~dimension:1 ~path:None ~represents_multiple_values:true
+        Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+          ~represents_multiple_values:true
       in
       Dom.Mem.add_stack (Loc.of_id id) (Dom.Val.of_loc arr_loc) mem
       |> Dom.Mem.add_heap (Loc.append_field arr_loc fn)
@@ -1576,15 +1577,15 @@ module JavaString = struct
     {exec; check= no_check}
 
 
-  let create_with_length {pname; node_hash; location} ~ret:(id, _) ~length_itv mem =
+  let create_with_length {pname; caller_pname; node_hash; location} ~ret:(id, _) ~length_itv mem =
     let arr_loc =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:0
-        ~dimension:1 ~path:None ~represents_multiple_values:false
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:0 ~dimension:1 ~path:None
+        ~represents_multiple_values:false
       |> Loc.of_allocsite
     in
     let elem_alloc =
-      Allocsite.make pname ~caller_pname:(Dom.Mem.get_proc_name mem) ~node_hash ~inst_num:1
-        ~dimension:1 ~path:None ~represents_multiple_values:true
+      Allocsite.make pname ~caller_pname ~node_hash ~inst_num:1 ~dimension:1 ~path:None
+        ~represents_multiple_values:true
     in
     let traces = Trace.(Set.singleton location ArrayDeclaration) in
     Dom.Mem.add_stack (Loc.of_id id) (Dom.Val.of_loc arr_loc) mem

--- a/infer/src/bufferoverrun/bufferOverrunOndemandEnv.ml
+++ b/infer/src/bufferoverrun/bufferOverrunOndemandEnv.ml
@@ -17,8 +17,7 @@ type t =
   ; may_last_field: SPath.partial -> bool
   ; entry_location: Location.t
   ; integer_type_widths: Typ.IntegerWidths.t
-  ; class_name: Typ.name option
-  ; proc_desc: Procdesc.t }
+  ; class_name: Typ.name option }
 
 let mk pdesc =
   let pname = Procdesc.get_proc_name pdesc in
@@ -95,10 +94,4 @@ let mk pdesc =
     in
     let entry_location = Procdesc.Node.get_loc (Procdesc.get_start_node pdesc) in
     let class_name = Procname.get_class_type_name pname in
-    { tenv
-    ; typ_of_param_path
-    ; may_last_field
-    ; entry_location
-    ; integer_type_widths
-    ; class_name
-    ; proc_desc= pdesc }
+    {tenv; typ_of_param_path; may_last_field; entry_location; integer_type_widths; class_name}

--- a/infer/src/bufferoverrun/bufferOverrunOndemandEnv.mli
+++ b/infer/src/bufferoverrun/bufferOverrunOndemandEnv.mli
@@ -15,7 +15,6 @@ type t =
         (** if the path is a last field of a class in C++ *)
   ; entry_location: Location.t  (** location of entry node *)
   ; integer_type_widths: Typ.IntegerWidths.t  (** bit sizes of integer types *)
-  ; class_name: Typ.name option  (** class name of the procedure being analyzed *)
-  ; proc_desc: Procdesc.t  (** procdesc of the procedure being analyzed *) }
+  ; class_name: Typ.name option  (** class name of the procedure being analyzed *) }
 
 val mk : Procdesc.t -> Tenv.t -> Typ.IntegerWidths.t -> t

--- a/infer/src/bufferoverrun/bufferOverrunUtils.mli
+++ b/infer/src/bufferoverrun/bufferOverrunUtils.mli
@@ -12,7 +12,8 @@ module PO = BufferOverrunProofObligations
 
 module ModelEnv : sig
   type model_env =
-    { pname: Procname.t
+    { pname: Procname.t (* the name of the builtin *)
+    ; caller_pname: Procname.t option (* caller of the builtin *)
     ; node_hash: int
     ; location: Location.t
     ; tenv: Tenv.t
@@ -21,12 +22,15 @@ module ModelEnv : sig
 
   val mk_model_env :
        Procname.t
+    -> ?caller_pname:Procname.t
     -> node_hash:int
     -> Location.t
     -> Tenv.t
     -> Typ.IntegerWidths.t
     -> BufferOverrunAnalysisSummary.get_summary
     -> model_env
+  (** Make model environment. caller_pname is relevant only when the model environment is used to
+      process builtins. *)
 end
 
 module Exec : sig


### PR DESCRIPTION
As suggested by @skcho:

"It could make more sense that adding caller's proc name to ModelEnv, rather than OndemandEnv (which is in Dom.Mem), since the ondemand env is the data for evaluating parameter values on-demand."

Proc_desc in OnDemandEnv is only used when creating a new Allocsite to file the procname of the caller of the function creating the Allocsite. This is needed in order to not end up with two identical allocsites created in two different subprograms by the call to the same builtin. In these situations, we either have already the correct procname (we don't need to get it from OnDemandEnv) or ModeEnv is available and we could add the procname to ModeEnv.

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
