### PR TITLE
fixed dockerfile builds

### DIFF
--- a/docker/master-java/Dockerfile
+++ b/docker/master-java/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
       libgmp-dev \
       libmpfr-dev \
       libsqlite3-dev \
+      sqlite3 \
       make \
       opam \
       openjdk-11-jdk-headless \
@@ -53,7 +54,7 @@ RUN cd /infer && \
     DESTDIR="/infer-release" \
     libdir_relative_to_bindir="../lib"
 
-FROM debian:buster-slim AS executor
+FROM debian:bullseye-slim AS executor
 
 RUN apt-get update && apt-get install --yes --no-install-recommends sqlite3
 

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
       libgmp-dev \
       libmpfr-dev \
       libsqlite3-dev \
+      sqlite3 \
       make \
       opam \
       openjdk-11-jdk-headless \
@@ -58,7 +59,7 @@ RUN cd /infer && \
     DESTDIR="/infer-release" \
     libdir_relative_to_bindir="../lib"
 
-FROM debian:buster-slim AS executor
+FROM debian:bullseye-slim AS executor
 
 RUN apt-get update && apt-get install --yes --no-install-recommends sqlite3
 


### PR DESCRIPTION
Building the docker images that compile infer from source under [master](https://github.com/facebook/infer/tree/main/docker/master) and [master-java](https://github.com/facebook/infer/tree/main/docker) currently result in compilation and execution failures.

The compilation error is due to a missing `sqlite3` apt dependency since the command is now used during the make process in `./infer/models/Makefile` line 68 `sqlite3 $(RESULTS_DB) $(SQL_DUMP_MODEL_SPECS) </dev/null`.

```
#12 259.8 [*ERROR**][5483] bash: line 1: sqlite3: command not found
#12 259.8 [*ERROR**][5483] make[2]: *** [Makefile:67: /infer/infer/lib/models.sql] Error 127      
#12 259.8 make[1]: *** [Makefile:437: infer_models] Error 2                                       
#12 259.8 make[1]: Leaving directory '/infer'                                                     
#12 259.8 make: *** [Makefile:449: opt] Error 2                                                   
#12 259.9                                                                                         
#12 259.9   compilation failure; you can try running                                              
#12 259.9                                                                                         
#12 259.9     make clean
#12 259.9     './build-infer.sh' java
#12 259.9
```

The build phase is performed by debian bullseye whereas execution is performed by debian buster (older libc) which results in the following error when attempting to execute:

```
root@4212e6b6b322:/home/wsl2/# infer --help
infer: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by infer)        
infer: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /infer/lib/infer/infer/bin/../libso/libsqlite3.so.0)

root@4212e6b6b322:/home/wsl2/# ls /lib/x86_64-linux-gnu/libc
libc-2.28.so        libcap-ng.so.0      libcom_err.so.2     libcrypt-2.28.so                      libc.so.6           libcap-ng.so.0.0.0  libcom_err.so.2.1   libcrypt.so.1
```

----

The short fixes to the Dockerfiles have been tested on a WSL2 Ubuntu 20.04 host running docker desktop. 

After making the changes, infer was built and run successfully using `docker build -t infer .`