### PR TITLE
[python] set version of Python to 3.8 on GitHub Actions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -79,6 +79,11 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
       - name: Get OS version
         uses: sersoft-gmbh/os-version-action@v1
         id: os-version


### PR DESCRIPTION

This is already fixing the Linux CI job on GitHub. Still looking into why it does not work for macOS.