### PR TITLE
[java] Support running analysis on JAR without sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,8 @@ endif
 ifneq ($(MVN),no)
 BUILD_SYSTEMS_TESTS += \
 	mvn \
-	jar
+	jar \
+	jar_without_sources
 endif
 endif # BUILD_JAVA_ANALYZERS
 

--- a/infer/src/java/jClasspath.ml
+++ b/infer/src/java/jClasspath.ml
@@ -220,7 +220,9 @@ let with_classpath ~f source =
         load_from_arguments path sources
   in
   if String.Map.is_empty classpath.sources then
-    L.(die InternalError) "Failed to load any Java source code" ;
+    L.user_warning "No Java source code loaded. Analyzing JAR/WAR files directly" ;
+  if String.Map.is_empty classpath.sources && JBasics.ClassSet.is_empty classpath.classes then
+    L.(die InternalError) "Failed to load any Java source or class files" ;
   L.(debug Capture Quiet)
     "Translating %d source files (%d classes)@."
     (String.Map.length classpath.sources)

--- a/infer/tests/build_systems/jar_without_sources/Makefile
+++ b/infer/tests/build_systems/jar_without_sources/Makefile
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+TESTS_DIR = ../..
+
+INFERPRINT_OPTIONS = --issues-tests
+
+MVN_DIR = ../codetoanalyze/mvn/simple_app
+SOURCES = $(MVN_DIR)/pom.xml $(shell find $(MVN_DIR) -type f -name '*.java')
+JAR_FILE = $(MVN_DIR)/target/simple-app-1.0-SNAPSHOT.jar
+
+CLEAN_EXTRA = $(TARGET)
+
+include $(TESTS_DIR)/infer.make
+
+infer-out/report.json: $(JAVA_DEPS) $(SOURCES)
+	$(QUIET)cd $(MVN_DIR) && $(MVN) --quiet clean install
+	$(QUIET)$(call silent_on_success,Testing mvn Java integration: $*,\
+		$(INFER_BIN) --project-root $(TESTS_DIR) --generated-classes $(JAR_FILE))

--- a/infer/tests/build_systems/jar_without_sources/issues.exp
+++ b/infer/tests/build_systems/jar_without_sources/issues.exp
@@ -1,0 +1,3 @@
+/hello/Hello.class, hello.Hello.mayCauseNPE():void, 3, NULL_DEREFERENCE, no_bucket, ERROR, [start of procedure mayCauseNPE()]
+/hello/Hello.class, hello.Hello.mayLeakResource():void, 6, RESOURCE_LEAK, no_bucket, ERROR, [start of procedure mayLeakResource(),Taking false branch]
+/hello/Hello.class, hello.Hello.twoResources():void, 14, RESOURCE_LEAK, no_bucket, ERROR, [start of procedure twoResources(),Taking true branch,exception java.io.IOException]


### PR DESCRIPTION
Summary:
This commit introduces the ability to run infer on JAR without sources, by iterating through classes instead of source files (when there is no source files to analyze).
The feature to run on JAR files were introduced #1673.

Closes #1613.

With helps from Jules Villard <jul@meta.com> for code pointers.

Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up your development environment and run tests.
