### PR TITLE
Add all pnames to CallGraph in AnalysisDependencyGraph

### DIFF
--- a/infer/src/backend/AnalysisDependencyGraph.ml
+++ b/infer/src/backend/AnalysisDependencyGraph.ml
@@ -53,7 +53,9 @@ let build ~changed_files =
           | Some deps ->
               Procname.HashSet.add proc_name deps
           | None ->
-              Procname.HashSet.singleton proc_name |> SourceFile.Hash.add tenv_deps src_file ) ) ;
+              Procname.HashSet.singleton proc_name |> SourceFile.Hash.add tenv_deps src_file ) ;
+      (* Ensure proc_name is part of the graph if it has not been referenced yet *)
+      if not (CallGraph.mem_procname graph proc_name) then CallGraph.create_node graph proc_name [] ) ;
   (* Then, flag in [graph] any procedure with a summary depending (transitively) on either (1) a
      deleted procedure, (2) the tenv of a changed file or (3) the summary of a changed procedure. *)
   List.iter !deleted_procs ~f:(CallGraph.flag_reachable graph) ;

--- a/infer/tests/build_systems/incremental_analysis_remove_file/analysis_dependency_invalidation_graph.dot
+++ b/infer/tests/build_systems/incremental_analysis_remove_file/analysis_dependency_invalidation_graph.dot
@@ -5,9 +5,11 @@ digraph callgraph {
   N0 [ label = "c\nflag=true" ];
   N0 -> N1 ;
 
-  N2 [ label = "a\nflag=true" ];
-  N2 -> N3 ;
+  N4 [ label = "main\nflag=true" ];
 
-  N3 [ label = "main\nflag=true" ];
+  N2 [ label = "d\nflag=false" ];
+
+  N3 [ label = "a\nflag=true" ];
+  N3 -> N4 ;
 
 }

--- a/infer/tests/build_systems/incremental_analysis_remove_file/invalidation_stats.exp
+++ b/infer/tests/build_systems/incremental_analysis_remove_file/invalidation_stats.exp
@@ -1,1 +1,1 @@
-Incremental analysis: Invalidated 4 of 4 procedure summaries, and file-level analyses for 3 distinct files 
+Incremental analysis: Invalidated 4 of 5 procedure summaries, and file-level analyses for 3 distinct files 


### PR DESCRIPTION
This ensures that function never called are still invalidated.