### PR TITLE
Fix argument issue on Makefile for clang plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,20 +514,20 @@ clang_plugin: clang_setup
 	  CC="$(CC)" CXX="$(CXX)" \
 	  CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" \
 	  CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" \
-	  LOCAL_CLANG=$(CLANG_PREFIX)/bin/clang \
-	  CLANG_PREFIX=$(CLANG_PREFIX) \
-	  CLANG_INCLUDES=$(CLANG_INCLUDES) \
-	  SDKPATH=$(XCODE_ISYSROOT) \
+	  LOCAL_CLANG="$(CLANG_PREFIX)/bin/clang" \
+	  CLANG_PREFIX="$(CLANG_PREFIX)" \
+	  CLANG_INCLUDES="$(CLANG_INCLUDES)" \
+	  SDKPATH="$(XCODE_ISYSROOT)" \
 	)
 	$(QUIET)$(call silent_on_success,Building clang plugin OCaml interface,\
 	$(MAKE) -C $(FCP_DIR)/clang-ocaml build/clang_ast_proj.ml build/clang_ast_proj.mli \
-	  CC=$(CC) CXX=$(CXX) \
+	  CC="$(CC)" CXX="$(CXX)" \
 	  CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" \
 	  CPP="$(CPP)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" \
-	  LOCAL_CLANG=$(CLANG_PREFIX)/bin/clang \
-	  CLANG_PREFIX=$(CLANG_PREFIX) \
-	  CLANG_INCLUDES=$(CLANG_INCLUDES) \
-	  SDKPATH=$(XCODE_ISYSROOT) \
+	  LOCAL_CLANG="$(CLANG_PREFIX)/bin/clang" \
+	  CLANG_PREFIX="$(CLANG_PREFIX)" \
+	  CLANG_INCLUDES="$(CLANG_INCLUDES)" \
+	  SDKPATH="$(XCODE_ISYSROOT)" \
 	)
 .PHONY: clang_plugin_test
 clang_plugin_test: clang_setup


### PR DESCRIPTION
In clang_plugin of makefile, some of arguments aren't escaped with "". Then it's build break on some environment.

The following is error case's example. Then this change will solve the issue with "" escape.

```
[01:22:22][82676] Building clang plugin OCaml interface... [*ERROR**][82676] *** ERROR 'Building clang plugin OCaml interface' [*ERROR**][82676] *** command: ' make -C /Users/hidenorly/work/infer/facebook-clang-plugins/clang-ocaml build/clang_ast_proj.ml build/clang_ast_proj.mli CC=clang CXX=clang++ -std=gnu++11 CFLAGS="-g -O2" CXXFLAGS="-g -O2" CPP="clang -E" LDFLAGS="" LIBS="" LOCAL_CLANG=/Users/hidenorly/work/infer/facebook-clang-plugins/clang/install/bin/clang CLANG_PREFIX=/Users/hidenorly/work/infer/facebook-clang-plugins/clang/install CLANG_INCLUDES=/Users/hidenorly/work/infer/facebook-clang-plugins/clang/install/include SDKPATH=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk ' [*ERROR**][82676] *** CWD: '/Users/hidenorly/work/infer' [*ERROR**][82676] *** stdout:
[*ERROR**][82676] *** stderr:
[*ERROR**][82676] make: invalid option -- =
[*ERROR**][82676] make: invalid option -- g
[*ERROR**][82676] make: invalid option -- u
[*ERROR**][82676] make: invalid option -- +
[*ERROR**][82676] make: invalid option -- +
[*ERROR**][82676] make: invalid option -- 1
[*ERROR**][82676] make: invalid option -- 1
[*ERROR**][82676] Usage: make [options] [target] ...
```

Since this is makefile, I did build test with ```./build-infer.sh clang``` and ```./autogen.sh; ./configure; make``` And build was success with this modification.
