### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 website/** linguist-documentation
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
A few files (see below) are being interpreted as SML; this corrects Linguist to treat them as OCaml.

<img width="889" alt="Screenshot 2024-04-01 at 16 34 37" src="https://github.com/facebook/infer/assets/1146876/cfc2911b-f5d5-4586-8440-56d77e6cbad2">
