### PR TITLE
[website] Clarify issue type`VECTOR_INVALIDATION` example with pointer assignment

### DIFF
--- a/infer/documentation/issues/INEFFICIENT_KEYSET_ITERATOR.md
+++ b/infer/documentation/issues/INEFFICIENT_KEYSET_ITERATOR.md
@@ -1,5 +1,5 @@
 This issue is raised when
-- iterating over a HashMap with `ketSet()` iterator
+- iterating over a HashMap with `keySet()` iterator
 - looking up the key each time
 
 Example:

--- a/infer/documentation/issues/PARAMETER_NOT_NULL_CHECKED.md
+++ b/infer/documentation/issues/PARAMETER_NOT_NULL_CHECKED.md
@@ -5,7 +5,7 @@ as an argument. Therefore it is only a warning. For example:
 
 ```objectivec
   -(int) foo:(A* a) {
-      B b* = [a foo]; // sending a message with receiver nil returns nil
+      B *b = [a foo]; // sending a message with receiver nil returns nil
       return b->x; // dereferencing b, potential NPE if you pass nil as the argument a.
   }
 ```

--- a/infer/documentation/issues/VECTOR_INVALIDATION.md
+++ b/infer/documentation/issues/VECTOR_INVALIDATION.md
@@ -10,6 +10,7 @@ For example:
 ```cpp
 void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   int* elt = &vec[1];
+  int* y = elt;
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array

--- a/infer/documentation/issues/VECTOR_INVALIDATION.md
+++ b/infer/documentation/issues/VECTOR_INVALIDATION.md
@@ -14,6 +14,6 @@ void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array
-  std::cout << *y << "\n"; // bad: elt might be invalid
+  std::cout << *y << "\n"; // bad: y might be invalid
 }
 ```

--- a/website/docs/all-issue-types.md
+++ b/website/docs/all-issue-types.md
@@ -2940,7 +2940,7 @@ void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array
-  std::cout << *y << "\n"; // bad: elt might be invalid
+  std::cout << *y << "\n"; // bad: y might be invalid
 }
 ```
 

--- a/website/docs/all-issue-types.md
+++ b/website/docs/all-issue-types.md
@@ -2936,6 +2936,7 @@ For example:
 ```cpp
 void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   int* elt = &vec[1];
+  int* y = elt;
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array

--- a/website/docs/all-issue-types.md
+++ b/website/docs/all-issue-types.md
@@ -798,7 +798,7 @@ void makeAllZero_impure(ArrayList<Foo> list) {
 Reported as "Inefficient Keyset Iterator" by [inefficient-keyset-iterator](/docs/next/checker-inefficient-keyset-iterator).
 
 This issue is raised when
-- iterating over a HashMap with `ketSet()` iterator
+- iterating over a HashMap with `keySet()` iterator
 - looking up the key each time
 
 Example:

--- a/website/versioned_docs/version-1.0.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.0.0/all-issue-types.md
@@ -2116,7 +2116,7 @@ void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array
-  std::cout << *y << "\n"; // bad: elt might be invalid
+  std::cout << *y << "\n"; // bad: y might be invalid
 }
 ```
 

--- a/website/versioned_docs/version-1.0.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.0.0/all-issue-types.md
@@ -903,7 +903,7 @@ void makeAllZero_impure(ArrayList<Foo> list) {
 Reported as "Inefficient Keyset Iterator" by [inefficient-keyset-iterator](/docs/1.0.0/checker-inefficient-keyset-iterator).
 
 This issue is raised when
-- iterating over a HashMap with `ketSet()` iterator
+- iterating over a HashMap with `keySet()` iterator
 - looking up the key each time
 
 Instead, it is more efficient to iterate over the loop with `entrySet` which returns key-vaue pairs and gets rid of the hashMap lookup.
@@ -1070,7 +1070,7 @@ parameter is `nil`. For example:
 
 ```objectivec
   -(int) foo {
-      B b* = [self->_a foo]; // sending a message with receiver nil returns nil
+      B *b = [self->_a foo]; // sending a message with receiver nil returns nil
       return b->x; // dereferencing b, potential NPE if you pass nil as the argument a.
   }
 ```
@@ -1323,7 +1323,7 @@ as an argument. Therefore it is only a warning. For example:
 
 ```objectivec
   -(int) foo:(A* a) {
-      B b* = [a foo]; // sending a message with receiver nil returns nil
+      B *b = [a foo]; // sending a message with receiver nil returns nil
       return b->x; // dereferencing b, potential NPE if you pass nil as the argument a.
   }
 ```

--- a/website/versioned_docs/version-1.0.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.0.0/all-issue-types.md
@@ -2112,6 +2112,7 @@ For example:
 ```C++
 void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   int* elt = &vec[1];
+  int* y = elt;
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array

--- a/website/versioned_docs/version-1.1.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.1.0/all-issue-types.md
@@ -2279,7 +2279,7 @@ void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array
-  std::cout << *y << "\n"; // bad: elt might be invalid
+  std::cout << *y << "\n"; // bad: y might be invalid
 }
 ```
 

--- a/website/versioned_docs/version-1.1.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.1.0/all-issue-types.md
@@ -2275,6 +2275,7 @@ For example:
 ```C++
 void deref_vector_element_after_push_back_bad(std::vector<int>& vec) {
   int* elt = &vec[1];
+  int* y = elt;
   vec.push_back(42); // if the array backing the vector was full already, this
                      // will re-allocate it and copy the previous contents
                      // into the new array, then delete the previous array

--- a/website/versioned_docs/version-1.1.0/all-issue-types.md
+++ b/website/versioned_docs/version-1.1.0/all-issue-types.md
@@ -982,7 +982,7 @@ void makeAllZero_impure(ArrayList<Foo> list) {
 Reported as "Inefficient Keyset Iterator" by [inefficient-keyset-iterator](/docs/checker-inefficient-keyset-iterator).
 
 This issue is raised when
-- iterating over a HashMap with `ketSet()` iterator
+- iterating over a HashMap with `keySet()` iterator
 - looking up the key each time
 
 Instead, it is more efficient to iterate over the loop with `entrySet` which returns key-vaue pairs and gets rid of the hashMap lookup.
@@ -1154,7 +1154,7 @@ parameter is `nil`. For example:
 
 ```objectivec
   -(int) foo {
-      B b* = [self->_a foo]; // sending a message with receiver nil returns nil
+      B *b = [self->_a foo]; // sending a message with receiver nil returns nil
       return b->x; // dereferencing b, potential NPE if you pass nil as the argument a.
   }
 ```
@@ -1481,7 +1481,7 @@ as an argument. Therefore it is only a warning. For example:
 
 ```objectivec
   -(int) foo:(A* a) {
-      B b* = [a foo]; // sending a message with receiver nil returns nil
+      B *b = [a foo]; // sending a message with receiver nil returns nil
       return b->x; // dereferencing b, potential NPE if you pass nil as the argument a.
   }
 ```


### PR DESCRIPTION
## Summary
This PR updates the VECTOR_INVALIDATION documentation example to include a missing line of code that explicitly assigns a pointer. The added line `int* y = elt;` clarifies the example by showing the exact pointer that is dereferenced after the vector modification. The missing line comes from the testcase file `infer/tests/codetoanalyze/cpp/pulse/vector.cpp`

## Motivation
The current documentation example might be confusing for readers, as it dereferences a pointer `y` which was not explicitly assigned in the code snippet. Including the pointer assignment makes the example clearer and demonstrates the potential invalidation issue more effectively.

## Changes
- Added `int* y = elt;` in the VECTOR_INVALIDATION example.
- Updated across four documentation files to maintain consistency.

Thank you for considering this documentation improvement.
