### PR TITLE
docs: add local development quickstart to README (fixes #1926)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,38 @@ Started](http://fbinfer.com/docs/getting-started) page for
 details on how to install packaged versions of Infer. To build Infer
 from source, see [INSTALL.md](./INSTALL.md).
 
+### Local development quickstart
+
+```sh
+./build-infer.sh
+make devsetup
+make -j              # default BUILD_MODE=dev (treat warnings as errors)
+make -j test_build   # quick sanity check
+make -j4 test        # run tests (adjust 4 to your CPU cores)
+```
+
+Faster OCaml inner loop:
+
+```sh
+make -j -C infer/src check   # type-check only
+make -j -C infer/src byte    # fast bytecode build for small examples
+```
+
+Temporarily ignore warnings while iterating (clean up before committing):
+
+```sh
+make BUILD_MODE=dev-noerror -j
+```
+
+Analyze a project you build with Make or Maven:
+
+```sh
+infer run -- make <target>
+infer run -- mvn <target>
+```
+
+See [INSTALL.md](./INSTALL.md) for platform-specific details and the website docs for wrapping real builds.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -22,5 +54,3 @@ Infer is MIT-licensed.
 
 Note: Enabling Java support may require you to download and install 
 components licensed under the GPL.
-
-


### PR DESCRIPTION
Adds a concise “Local development quickstart” so new contributors can build and run tests immediately without leaving the page.
Uses build-infer.sh + make devsetup.
Documents fast OCaml inner loops (-C infer/src check and byte).
Mentions BUILD_MODE=dev-noerror for temporary iteration.
Shows infer run -- make|mvn for analyzing real builds.

Mirrors and links to INSTALL.md and website docs to avoid divergence.