### PR TITLE
fix clang build with glibc 2.42 re: struct termio

### DIFF
--- a/facebook-clang-plugins/clang/src/glibc_2.42_struct_termio_interceptors.patch
+++ b/facebook-clang-plugins/clang/src/glibc_2.42_struct_termio_interceptors.patch
@@ -1,0 +1,64 @@
+From 59978b21ad9c65276ee8e14f26759691b8a65763 Mon Sep 17 00:00:00 2001
+From: Tom Stellard <tstellar@redhat.com>
+Date: Mon, 28 Apr 2025 13:45:11 -0700
+Subject: [PATCH] [sanitizer_common] Remove interceptors for deprecated struct
+ termio (#137403)
+
+This struct will be removed from glibc-2.42 and has been deprecated for
+a very long time.
+
+Fixes #137321
+---
+ .../sanitizer_common_interceptors_ioctl.inc               | 8 --------
+ .../sanitizer_common/sanitizer_platform_limits_posix.cpp  | 3 ---
+ .../sanitizer_common/sanitizer_platform_limits_posix.h    | 1 -
+ 3 files changed, 12 deletions(-)
+
+diff --git a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index f88f914b1d149..bc8f02826c614 100644
+--- a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -342,17 +342,9 @@ static void ioctl_table_fill() {
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCGETA, WRITE, struct_termio_sz);
+-#endif
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+-#endif
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+diff --git a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index b4d87ab6228e5..7a89bf1c74985 100644
+--- a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -494,9 +494,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-#if SANITIZER_GLIBC || SANITIZER_ANDROID
+-  unsigned struct_termio_sz = sizeof(struct termio);
+-#endif
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+diff --git a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index 348bb4f27aec3..fdc52aa56c493 100644
+--- a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1063,7 +1063,6 @@ extern unsigned struct_hd_geometry_sz;
+ extern unsigned struct_input_absinfo_sz;
+ extern unsigned struct_input_id_sz;
+ extern unsigned struct_mtpos_sz;
+-extern unsigned struct_termio_sz;
+ extern unsigned struct_vt_consize_sz;
+ extern unsigned struct_vt_sizes_sz;
+ extern unsigned struct_vt_stat_sz;

--- a/facebook-clang-plugins/clang/src/glibc_2.42_struct_termio_references.patch
+++ b/facebook-clang-plugins/clang/src/glibc_2.42_struct_termio_references.patch
@@ -1,0 +1,64 @@
+From c99b1bcd505064f2e086e6b1034ce0b0c91ea5b9 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Wed, 7 May 2025 10:06:10 +0200
+Subject: [PATCH] Remove reference to obsolete termio ioctls
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The termio ioctls are no longer used after commit 59978b21ad9c
+("[sanitizer_common] Remove interceptors for deprecated struct termio
+(#137403)"), remove them.  Fixes this build error:
+
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:765:27: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  765 |   unsigned IOCTL_TCGETA = TCGETA;
+      |                           ^~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:769:27: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  769 |   unsigned IOCTL_TCSETA = TCSETA;
+      |                           ^~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:770:28: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  770 |   unsigned IOCTL_TCSETAF = TCSETAF;
+      |                            ^~~~~~~
+../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:771:28: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
+  771 |   unsigned IOCTL_TCSETAW = TCSETAW;
+      |                            ^~~~~~~
+Part-of: https://github.com/llvm/llvm-project/pull/138822
+Closes: https://github.com/llvm/llvm-project/pull/138822
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp  | 4 ----
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.h    | 4 ----
+ 2 files changed, 8 deletions(-)
+
+diff --git a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index ef4b8a85d6634..ea8cc306268cb 100644
+--- a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -764,12 +764,8 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_SOUND_PCM_WRITE_FILTER = SOUND_PCM_WRITE_FILTER;
+ #endif // SOUND_VERSION
+   unsigned IOCTL_TCFLSH = TCFLSH;
+-  unsigned IOCTL_TCGETA = TCGETA;
+   unsigned IOCTL_TCGETS = TCGETS;
+   unsigned IOCTL_TCSBRK = TCSBRK;
+   unsigned IOCTL_TCSBRKP = TCSBRKP;
+-  unsigned IOCTL_TCSETA = TCSETA;
+-  unsigned IOCTL_TCSETAF = TCSETAF;
+-  unsigned IOCTL_TCSETAW = TCSETAW;
+   unsigned IOCTL_TCSETS = TCSETS;
+   unsigned IOCTL_TCSETSF = TCSETSF;
+diff --git a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index 9e11dd9911d9d..24966523f3a02 100644
+--- a/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1289,11 +1289,7 @@ extern unsigned IOCTL_SNDCTL_COPR_SENDMSG;
+ extern unsigned IOCTL_SNDCTL_COPR_WCODE;
+ extern unsigned IOCTL_SNDCTL_COPR_WDATA;
+ extern unsigned IOCTL_TCFLSH;
+-extern unsigned IOCTL_TCGETA;
+ extern unsigned IOCTL_TCGETS;
+ extern unsigned IOCTL_TCSBRK;
+ extern unsigned IOCTL_TCSBRKP;
+-extern unsigned IOCTL_TCSETA;
+-extern unsigned IOCTL_TCSETAF;
+-extern unsigned IOCTL_TCSETAW;
+ extern unsigned IOCTL_TCSETS;

--- a/facebook-clang-plugins/clang/src/prepare_clang_src.sh
+++ b/facebook-clang-plugins/clang/src/prepare_clang_src.sh
@@ -25,6 +25,8 @@ CLANG_PREBUILD_PATCHES=(
     "$SCRIPT_DIR/err_ret_local_block.patch"
     "$SCRIPT_DIR/mangle_suppress_errors.patch"
     "$SCRIPT_DIR/objc_method_decl.patch"
+    "$SCRIPT_DIR/glibc_2.42_struct_termio_interceptors.patch"
+    "$SCRIPT_DIR/glibc_2.42_struct_termio_references.patch"
 )
 
 mkdir -p "${SCRIPT_DIR}/download"


### PR DESCRIPTION
I hit some issues building Infer from source in my Arch Linux dev environment. The problem seems to be specific to compiling against glibc 2.42, which Arch [recently accepted into its official repositories](https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/commit/3543edc0a9e583f9c3880c197d83409c5e8d4020).

The fix in this PR is to backport fixes from LLVM upstream for https://github.com/llvm/llvm-project/issues/137321

- https://github.com/llvm/llvm-project/commit/59978b2
- https://github.com/llvm/llvm-project/commit/c99b1bc