### PR TITLE
ignore suppressed issues for process exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ BUILD_SYSTEMS_TESTS += \
   infer-debug \
   j1 \
   missing_deps \
+  pass_on_suppression \
   procs_to_analyze \
   project_root_rel \
   pulse_messages_c \

--- a/infer/src/integration/Driver.ml
+++ b/infer/src/integration/Driver.ml
@@ -365,6 +365,7 @@ let fail_on_issue_epilogue () =
   match Utils.read_file issues_json with
   | Ok lines ->
       let issues = Jsonbug_j.report_of_string @@ String.concat ~sep:"" lines in
+      let issues = List.filter ~f:(fun (x : Jsonbug_j.jsonbug) -> not x.suppressed) issues in
       if not (List.is_empty issues) then L.exit Config.fail_on_issue_exit_code
   | Error error ->
       L.internal_error "Failed to read report file '%s': %s@." issues_json error ;

--- a/infer/tests/build_systems/codetoanalyze/hello_suppression.c
+++ b/infer/tests/build_systems/codetoanalyze/hello_suppression.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdlib.h>
+
+void test() {
+  int* s = NULL;
+  *s = 42; // @infer-ignore NULLPTR_DEREFERENCE
+}

--- a/infer/tests/build_systems/pass_on_suppression/Makefile
+++ b/infer/tests/build_systems/pass_on_suppression/Makefile
@@ -1,0 +1,40 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+TESTS_DIR = ../..
+
+include $(TESTS_DIR)/base.make
+
+CODETOANALYZE_DIR = ../codetoanalyze
+
+CLANG_OPTIONS = -c
+INFER_OPTIONS = --project-root $(CODETOANALYZE_DIR) --fail-on-issue
+INFERPRINT_OPTIONS = --issues-tests
+
+SOURCES = $(CODETOANALYZE_DIR)/hello_suppression.c
+CLEAN_EXTRA = $(SOURCES:$(CODETOANALYZE_DIR)/%.c=%.o)
+
+default: test
+
+issues.exp.test: $(CLANG_DEPS) $(SOURCES)
+	$(QUIET)$(call silent_on_success,Testing Infer passes on suppressed issue,\
+	  exit_code=0; $(INFER_BIN) --fail-on-issue -- clang $(CLANG_OPTIONS) $(SOURCES) || exit_code=$$?; \
+	  echo "infer exit code: $$exit_code" > $@)
+
+.PHONY: print
+print: issues.exp.test
+
+.PHONY: test
+test: issues.exp.test
+	$(QUIET)cd $(TESTS_DIR) && \
+	$(call check_no_diff,$(TEST_REL_DIR)/issues.exp,$(TEST_REL_DIR)/issues.exp.test)
+
+.PHONY: replace
+replace: issues.exp.test
+	cp $< issues.exp
+
+.PHONY: clean
+clean:
+	rm -rf issues.exp.test infer-out $(CLEAN_EXTRA)

--- a/infer/tests/build_systems/pass_on_suppression/issues.exp
+++ b/infer/tests/build_systems/pass_on_suppression/issues.exp
@@ -1,0 +1,1 @@
+infer exit code: 0


### PR DESCRIPTION
In my usage, `infer run` fails with a non-zero exit code even after I have suppressed all issues in my C project with `@infer-ignore` comments (along with appropriate `.inferconfig` settings).

I tracked this down to how `fail_on_issue_epilogue()` maps presence/absence of issues to the overall process exit code. The fix in this PR is to make Infer only return a non-zero exit code if one or more _unsuppressed_ issues exist. In other words, Infer should treat a suppressed issue as equivalent to an entirely non-existent issue, for the purposes of the overall `infer run` exit code.

Please let me know if there are backwards-compatibility concerns that would require this behavior to be gated by an opt-in CLI argument. I am hoping it is acceptable to change the default behavior in this manner, in order to follow the principle of least surprise for people (like myself) using Infer in their CI pipelines.

I've added a test for this behavior, based on the existing `fail_on_issue` testcase. I hope the latter is an acceptable template for a new test; please let me know if a different testcase would make for a better starting point.