### PR TITLE
Fix Get Infer command in 00-getting-started.md

### DIFF
--- a/website/docs/00-getting-started.md
+++ b/website/docs/00-getting-started.md
@@ -9,13 +9,14 @@ You can use our binary releases, build infer from source, or use our Docker imag
 
 Find our latest [binary release here](https://github.com/facebook/infer/releases/latest). Download
 the tarball then extract it anywhere on your system to start using infer. For example, this
-downloads infer in /opt on Linux (replace `VERSION` with the latest release, eg `VERSION=1.0.0`):
+downloads infer in /opt on Linux (replace `VERSION` with the latest release, eg `VERSION=1.2.0`):
 
 ```bash
 VERSION=0.XX.Y; \
-curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
+ARCH=$(uname -m) \
+curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux-$ARCH-v$VERSION.tar.xz" \
 | sudo tar -C /opt -xJ && \
-sudo ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+sudo ln -s "/opt/infer-linux-$ARCH-v$VERSION/bin/infer" /usr/local/bin/infer
 ```
 
 If the binaries do not work for you, or if you would rather build infer from
@@ -29,3 +30,4 @@ Alternatively, use our [Docker images](https://github.com/facebook/infer/tree/ma
 
 Try Infer on a small example on
 [Codeboard](https://codeboard.io/projects/11587?view=2.1-21.0-22.0).
+


### PR DESCRIPTION
I was unable to install even after running the commands as in Getting Started.
This fixes that problem.