### PR TITLE
Remove unused imports

### DIFF
--- a/infer/tests/codetoanalyze/java/starvation/Binders.java
+++ b/infer/tests/codetoanalyze/java/starvation/Binders.java
@@ -12,7 +12,6 @@ import android.net.wifi.WifiManager;
 import android.os.Binder;
 import android.os.RemoteException;
 import android.support.annotation.UiThread;
-import android.view.Display;
 
 class Binders {
   Binder b;


### PR DESCRIPTION
After bc3869e4f183d6646bb34804fd03bcdd748e0e7f importing `android.view.Display` is no longer needed.

Checkstyle does not report more unused imports.