### PR TITLE
[ci] prevent duplicated CI jobs between PRs and pushes to main

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,8 +1,10 @@
 name: build
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - "main"
+  pull_request: {}
 
 env:
   USER_LLVM: "yes"


### PR DESCRIPTION
Split the GitHub Actions trigger between the case of merge to the main branch and the pull requests. Without these changes, the CI jobs is running twice when pull requests are submitted or updated.

However, there is a difference between the two triggers that is relevant for external contributions:
- the run on `push` will run the CI of the `HEAD` commit of the external branch
- the `pull_request` will run the CI on `HEAD` of the external branch rebased on the latest version of `main`

So the trigger on `pull_request` is a better predictor of the CI success once the pull request will be merged. For example, if the external contribution is based on a older version of the code, e.g. missing some newly added regression tests, the CI could pass on `push` because these new tests would not be triggered, but fail on `pull_request`. In this case, the pull_request test is the one to consider and having one test passing and the other failing could be confusing.
