### PR TITLE
[website] fix download link for infer binary on Linux

### DIFF
--- a/website/docs/00-getting-started.md
+++ b/website/docs/00-getting-started.md
@@ -13,9 +13,9 @@ downloads infer in /opt on Linux (replace `VERSION` with the latest release, eg 
 
 ```bash
 VERSION=0.XX.Y; \
-curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
+curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux-x86_64-v$VERSION.tar.xz" \
 | sudo tar -C /opt -xJ && \
-sudo ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+sudo ln -s "/opt/infer-linux-x86_64-v$VERSION/bin/infer" /usr/local/bin/infer
 ```
 
 If the binaries do not work for you, or if you would rather build infer from


### PR DESCRIPTION
At the time of this commit, the naming convention for the infer binary artifact observed on https://github.com/facebook/infer/releases/tag/v1.2.0 seems conflict with the original one.
