### PR TITLE
[ci] fix PPX compilation errors

### DIFF
--- a/infer/src/pulse/PulseFormula.mli
+++ b/infer/src/pulse/PulseFormula.mli
@@ -50,7 +50,7 @@ module Term : sig
     | IsInt of t
   [@@deriving compare, equal, yojson_of]
 
-  module Set : Stdlib.Set.S [@@deriving compare]
+  module Set : Stdlib.Set.S
 end
 
 module Atom : sig
@@ -63,9 +63,9 @@ module Atom : sig
 
   val equal : Term.t -> Term.t -> t
 
-  module Set : Stdlib.Set.S [@@deriving compare]
+  module Set : Stdlib.Set.S
 
-  module Map : Stdlib.Map.S [@@deriving compare]
+  module Map : Stdlib.Map.S
 end
 
 module Formula : sig


### PR DESCRIPTION
Compiling Infer on the macOS ARM platform forces OPAM to use a more recent version of PPX. This leads to several compilation errors, including the following one:
```
File "src/pulse/PulseFormula.mli", line 53, characters 40-47:
53 |   module Set : Stdlib.Set.S [@@deriving compare]
                                             ^^^^^^^
Error: Ppxlib.Deriving: 'compare' is not a supported signature module
       declaration deriving generator
```
This PR addresses this error in an effort to make Infer cross-compile on the different platforms.

Once all the compilation errors have been addressed, the goal is to add macOS ARM (`macos-latest`) as a supported OS in [devsetup.yml](https://github.com/facebook/infer/blob/main/.github/workflows/devsetup.yml#L12).


