### PR TITLE
[opam] make the Makefile cross-platform

### DIFF
--- a/opam/Makefile
+++ b/opam/Makefile
@@ -13,20 +13,20 @@ all: infer.opam.locked infer-tests.opam.locked ocamlformat.opam.locked llvm.opam
 .PHONY: infer.opam.locked
 infer.opam.locked:
 	$(OPAM) lock --switch $(OPAMSWITCH) ./infer.opam
-	sed -i '/^ *"host-/d' $@
+	perl -i -pe '/^ *"host-/d' $@
 
 # depends on opam internal state
 .PHONY: infer-tests.opam.locked
 infer-tests.opam.locked:
 	sed -e 's/{with-test}//' -e 's/ & with-test}/}/' infer.opam > infer-tests.opam
 	$(OPAM) lock --switch $(OPAMSWITCH) ./infer-tests.opam
-	sed -i '/^ *"host-/d' $@
+	perl -i -pe '/^ *"host-/d' $@
 
 # depends on opam internal state
 .PHONY: ocamlformat.opam.locked
 ocamlformat.opam.locked:
 	$(OPAM) lock --switch $(OPAMSWITCH) ocamlformat
-	sed -i '/^ *"host-/d' $@
+	perl -i -pe '/^ *"host-/d' $@
 
 # depends on the local opam repo
 .PHONY: llvm.opam.locked
@@ -36,4 +36,4 @@ llvm.opam.locked:
 #	make paths to local patches relative
 #	sed is not perfect here, let's hope the path doesn't contain regexp-significant characters
 #	opam sometimes adds file://, sometimes not
-	sed -i -e "s#\(file://\)\?$$(realpath $(ROOT_DIR))/##g" $@
+	perl -i -pe "s#\(file://\)\?$$(realpath $(ROOT_DIR))/##g" $@


### PR DESCRIPTION
The original `sed` command is not working on macOS. It is possible to make the `sed` command cross-platform but according to the documentation using `perl` is a more stable way to perform the text updates.
