### PR TITLE
ci: add linux-aarch64 build to release workflow

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -59,7 +59,8 @@ jobs:
       matrix:
         os:
           - macOS-latest
-          - ubuntu-26.04
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         ocaml-compiler:
           - ocaml-variants.5.3.0+options,ocaml-option-flambda
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
testing