### PR TITLE
[infer][ci] add ARM macOS to the list of build targets

### DIFF
--- a/.github/workflows/devsetup.yml
+++ b/.github/workflows/devsetup.yml
@@ -11,11 +11,10 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-15-intel
+          - macos-26
+          - macos-26-intel
         ocaml-compiler:
           - ocaml-variants.5.3.0+options
-        build-mode:
-          - user-opam-switch
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,7 +36,7 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: ./build-infer.sh --yes --${{ matrix.build-mode }} java
+      - run: ./build-infer.sh --yes --user-opam-switch java
       - run: make -C infer/src clean
       - run: make -j -C infer/src byte
       - run: make -j direct_sil_pulse_test


### PR DESCRIPTION
We can now add the ARM macOS platform to the development setup tests now that the ARM build has been fixed in https://github.com/facebook/infer/commit/a50c6bf711d070c7b2382ee5baf55ec7060f12a9.
