### PR TITLE
docs: fix typos in comments and docstrings

### DIFF
--- a/infer/src/IR/BuiltinDecl.mli
+++ b/infer/src/IR/BuiltinDecl.mli
@@ -115,7 +115,7 @@ val __builtin_cxx_co_return : Procname.t
 val __builtin_cxx_co_await : Procname.t
 
 val __get_lazy_class : t
-(** returns the a LazyClass representation of its arguement (a type name). A LazyClass represents a
+(** returns the a LazyClass representation of its argument (a type name). A LazyClass represents a
     class that we know the name of but don't necessarily know if the class has been defined
     somewhere. *)
 

--- a/infer/src/IR/Procdesc.mli
+++ b/infer/src/IR/Procdesc.mli
@@ -310,7 +310,7 @@ val iter_instrs : (Node.t -> Sil.instr -> unit) -> t -> unit
 
 val replace_instrs : t -> f:(Node.t -> Sil.instr -> Sil.instr) -> bool
 (** Map and replace the instructions to be executed. Returns true if at least one substitution
-    occured. *)
+    occurred. *)
 
 val replace_instrs_using_context :
      t
@@ -319,7 +319,7 @@ val replace_instrs_using_context :
   -> context_at_node:(Node.t -> 'a)
   -> bool
 (** Map and replace the instructions to be executed using a context that we built with previous
-    instructions in the node. Returns true if at least one substitution occured. *)
+    instructions in the node. Returns true if at least one substitution occurred. *)
 
 val replace_instrs_by_using_context :
      t

--- a/infer/src/absint/ExplicitTrace.mli
+++ b/infer/src/absint/ExplicitTrace.mli
@@ -30,7 +30,7 @@ module DefaultCallPrinter : CallPrinter
 module type TraceElem = sig
   type elem_t
 
-  (** An [elem] which occured at [loc], after the chain of steps (usually calls) in [trace]. *)
+  (** An [elem] which occurred at [loc], after the chain of steps (usually calls) in [trace]. *)
   type t = private {elem: elem_t; loc: Location.t; trace: CallSite.t list}
 
   (** Both [pp] and [describe] simply call the same function on the trace element. *)

--- a/infer/src/backend/CallGraph.ml
+++ b/infer/src/backend/CallGraph.ml
@@ -112,7 +112,7 @@ let add_edge ({node_map} as graph) pname ~successor:successor_pname =
   let id = get_or_set_id graph pname in
   let successor = get_or_set_id graph successor_pname in
   let node = get_or_init_node node_map id pname in
-  (* initialize successor node if it isn't already initalized *)
+  (* initialize successor node if it isn't already initialized *)
   get_or_init_node node_map successor successor_pname |> ignore ;
   Node.add_successor node successor
 

--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -441,7 +441,7 @@ let exe_usage =
 (* HOWTO define a new command line and config file option.
 
    1. Add an entry in the following let...and...and... binding.  See the documentation in
-      [CommandLineOption.mli], and use the existing options as a guide.  Preferably the identifer
+      [CommandLineOption.mli], and use the existing options as a guide.  Preferably the identifier
       and long option name are the same modulo underscores versus hyphens.
 
       E.g. [and new_option = CLOpt.mk_bool ~long:"new-option"]

--- a/infer/src/base/IssueType.mli
+++ b/infer/src/base/IssueType.mli
@@ -46,7 +46,7 @@ type t = private
   ; visibility: visibility
   ; user_documentation: string option
   ; mutable default_severity: severity
-        (** used for documentation but can be overriden at report time *)
+        (** used for documentation but can be overridden at report time *)
   ; mutable enabled: bool
   ; mutable hum: string }
 [@@deriving compare]

--- a/infer/src/concurrency/AbstractAddress.ml
+++ b/infer/src/concurrency/AbstractAddress.ml
@@ -109,7 +109,7 @@ let pp_with_base pp_base fmt (base, accesses) =
   pp_rev_accesses fmt (List.rev accesses)
 
 
-(* A wrapper that ignores ProgramVar.Global_var translation_unit in comparision
+(* A wrapper that ignores ProgramVar.Global_var translation_unit in comparison
  * as we cannot add that ignore there due to issues with Siof
  * similar hack to D51588007 *)
 module SVar = struct


### PR DESCRIPTION
Seven spelling fixes across seven files — comments and docstrings only, no code logic changes:

- `IssueType.mli`: `overriden` → `overridden`
- `Config.ml`: `identifer` → `identifier`
- `ExplicitTrace.mli`: `occured` → `occurred`
- `Procdesc.mli`: `occured` → `occurred` (×2)
- `AbstractAddress.ml`: `comparision` → `comparison`
- `CallGraph.ml`: `initalized` → `initialized`
- `BuiltinDecl.mli`: `arguement` → `argument`

Note: `overriden` also appears in code identifiers (e.g. `xmdi_overriden_methods` in `CType_decl.ml`) — those are left unchanged to avoid API-breaking renames.