### PR TITLE
build-infer.sh: explicitly add --enable-rust-analyzers to configure

### DIFF
--- a/build-infer.sh
+++ b/build-infer.sh
@@ -293,6 +293,8 @@ if [ "$BUILD_PYTHON" == "no" ]; then
 fi
 if [ "$BUILD_RUST" == "no" ]; then
   CONFIGURE_PREPEND_OPTS+=" --disable-rust-analyzers"
+else
+  CONFIGURE_PREPEND_OPTS+=" --enable-rust-analyzers"
 fi
 if [ "$BUILD_SWIFT" == "no" ]; then
   CONFIGURE_PREPEND_OPTS+=" --disable-swift-analyzers"


### PR DESCRIPTION
This commit solves an issue where `./build-infer.sh rust` does not build infer's rust front-end. The source of this bug is that ./configure's default currently is to have rust disabled, so not adding `--disable-rust-analyzers` to its command line is not sufficient to enable rust.