### PR TITLE
ci] bump devsetup Java SDK from 11 to 25 (latest LTS)

### DIFF
--- a/.github/workflows/devsetup.yml
+++ b/.github/workflows/devsetup.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '25'
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3


### PR DESCRIPTION
Update the java-version in .github/workflows/devsetup.yml to Temurin 25, the current LTS release.
