### PR TITLE
[ci] fix the macOS build on the GitHub CI

### DIFF
--- a/opam/infer-tests.opam.locked
+++ b/opam/infer-tests.opam.locked
@@ -84,7 +84,6 @@ depends: [
   "ocaml-compiler-libs" {= "v0.17.0"}
   "ocaml-config" {= "3"}
   "ocaml-option-flambda" {= "1"}
-  "ocaml-option-fp" {= "1"}
   "ocaml-variants" {= "5.3.0+options"}
   "ocaml_intrinsics_kernel" {= "v0.17.1"}
   "ocamlbuild" {= "0.16.1"}

--- a/opam/infer.opam.locked
+++ b/opam/infer.opam.locked
@@ -84,7 +84,6 @@ depends: [
   "ocaml-compiler-libs" {= "v0.17.0"}
   "ocaml-config" {= "3"}
   "ocaml-option-flambda" {= "1"}
-  "ocaml-option-fp" {= "1"}
   "ocaml-variants" {= "5.3.0+options"}
   "ocaml_intrinsics_kernel" {= "v0.17.1"}
   "ocamlbuild" {= "0.16.1"}

--- a/opam/llvm.opam.locked
+++ b/opam/llvm.opam.locked
@@ -32,7 +32,6 @@ depends: [
   "ocaml-compiler" {= "5.3.0"}
   "ocaml-config" {= "3"}
   "ocaml-option-flambda" {= "1"}
-  "ocaml-option-fp" {= "1"}
   "ocaml-variants" {= "5.3.0+options"}
   "ocamlfind" {= "1.9.8"}
   "stdlib-shims" {= "0.3.0"}

--- a/opam/ocamlformat.opam.locked
+++ b/opam/ocamlformat.opam.locked
@@ -54,7 +54,6 @@ depends: [
   "ocaml-compiler" {= "5.3.0"}
   "ocaml-config" {= "3"}
   "ocaml-option-flambda" {= "1"}
-  "ocaml-option-fp" {= "1"}
   "ocaml-variants" {= "5.3.0+options"}
   "ocaml-version" {= "4.0.1"}
   "ocaml_intrinsics_kernel" {= "v0.17.1"}


### PR DESCRIPTION
The dependency `ocaml-option-fp` is not available for the macOS ARM platform when using OCaml with a version before 5.4.0: https://opam.ocaml.org/packages/ocaml-option-fp/ 

However, it seems that this package is added by `opam` when running on Linux but is not actually used anywhere. 

The macOS ARM build is fixed by https://github.com/facebook/infer/pull/2056 migrating the build to use OCaml 5.4.1 but this fix can be merged in the meantime if merging the OCaml 5.4.1 changes takes time.
