### PR TITLE
[rust][TreeBorrows] Pointer reference and mutability information

### DIFF
--- a/infer/src/IR/Typ.mli
+++ b/infer/src/IR/Typ.mli
@@ -64,6 +64,8 @@ val mk_type_quals :
 
 val is_const : type_quals -> bool
 
+val is_reference_on_source : type_quals -> bool
+
 val is_restrict : type_quals -> bool
 
 val is_volatile : type_quals -> bool

--- a/infer/src/rust/RustMir2Textual.ml
+++ b/infer/src/rust/RustMir2Textual.ml
@@ -244,6 +244,42 @@ let proc_name_from_binop (op : Charon.Generated_Expressions.binop) (typ : Textua
   (Textual.ProcDecl.of_binop bin_op, typ)
 
 
+let add_borrow_mut (borrow_kind : Charon.Generated_Expressions.borrow_kind) attrs =
+  match borrow_kind with
+  | BMut | BTwoPhaseMut | BUniqueImmutable ->
+      Textual.Attr.ptr_rust_mut :: attrs
+  | _ ->
+      Textual.Attr.ptr_rust_const :: attrs
+
+
+let add_ref_mut (ref_kind : Charon.Generated_Types.ref_kind) attrs =
+  match ref_kind with
+  | RMut ->
+      Textual.Attr.ptr_rust_mut :: attrs
+  | _ ->
+      Textual.Attr.ptr_rust_const :: attrs
+
+
+let get_rvalue_ptr_attrs (rvalue : Charon.Generated_Expressions.rvalue) =
+  match rvalue with
+  | RawPtr (_, ref_kind, _) ->
+      add_ref_mut ref_kind [Textual.Attr.ptr_rust_raw]
+  | RvRef (_, borrow_kind, _) ->
+      add_borrow_mut borrow_kind [Textual.Attr.ptr_rust_reference]
+  | _ ->
+      []
+
+
+let get_ty_ptr_attrs (rust_ty : Charon.Generated_Types.ty) =
+  match rust_ty with
+  | TRef (_, _, ref_kind) ->
+      add_ref_mut ref_kind [Textual.Attr.ptr_rust_reference]
+  | TRawPtr (_, ref_kind) ->
+      add_ref_mut ref_kind [Textual.Attr.ptr_rust_raw]
+  | _ ->
+      []
+
+
 (* Model Unqiue<T> and NonNull<T> as *T *)
 let is_pointer_type crate (name : Charon.Generated_Types.name) =
   let name = name |> List.map ~f:(name_of_path_element crate) in
@@ -329,7 +365,7 @@ and ty_to_textual_typ crate (rust_ty : Charon.Generated_Types.ty) : Textual.Typ.
   | TLiteral (TFloat _) ->
       Textual.Typ.Float
   | TRawPtr (ty, _) | TRef (_, ty, _) ->
-      Textual.Typ.mk_ptr (ty_to_textual_typ crate ty)
+      Textual.Typ.Ptr (ty_to_textual_typ crate ty, get_ty_ptr_attrs rust_ty)
   | TAdt type_decl_ref ->
       adt_ty_to_textual_typ crate type_decl_ref
   (* Generics *)
@@ -560,11 +596,11 @@ let mk_exp_from_rvalue ~loc crate (rvalue : Charon.Generated_Expressions.rvalue)
   | RvRef ({kind= PlaceLocal var_id; ty}, _, _metadata) ->
       let typ = ty_to_textual_typ crate ty in
       let exp = Textual.Exp.Lvar (place_map_find_id place_map var_id) in
-      (exp, Textual.Typ.mk_ptr typ)
+      (exp, Textual.Typ.Ptr (typ, get_rvalue_ptr_attrs rvalue))
   | RawPtr (place, _, _metadata) | RvRef (place, _, _metadata) ->
       let typ = ty_to_textual_typ crate place.ty in
       let exp = mk_exp_from_place ~loc crate place_map place in
-      (exp, Textual.Typ.mk_ptr typ)
+      (exp, Textual.Typ.Ptr (typ, get_rvalue_ptr_attrs rvalue))
   | Aggregate (kind, ops) -> (
       (* TODO: Handle non-empty aggregates as well *)
       let exps = List.map ~f:(fun op -> mk_exp_from_operand ~loc crate place_map op |> fst) ops in

--- a/infer/src/rust/unit/RustMir2TextualTestAggregates.ml
+++ b/infer/src/rust/unit/RustMir2TextualTestAggregates.ml
@@ -264,11 +264,11 @@ fn main() {
     type dummy::Adder = {}
 
     define dummy::main() : void {
-      local var_0: void, adder_1: dummy::Adder, three_2: int, var_3: *dummy::Adder
+      local var_0: void, adder_1: dummy::Adder, three_2: int, var_3: .rust_mut = "const" .rust_pointer = "reference" *dummy::Adder
       #node_0:
           store &var_0 <- null:void
-          store &var_3 <- &adder_1:*dummy::Adder
-          n0:*dummy::Adder = load &var_3
+          store &var_3 <- &adder_1:.rust_mut = "const" .rust_pointer = "reference" *dummy::Adder
+          n0:.rust_mut = "const" .rust_pointer = "reference" *dummy::Adder = load &var_3
           n1 = dummy::{dummy::Adder}::add(n0, 1, 2)
           store &three_2 <- n1:int
           jmp node_2
@@ -284,7 +284,7 @@ fn main() {
 
     }
 
-    define dummy::{dummy::Adder}::add(self_1: *dummy::Adder, a_2: int, b_3: int) : int {
+    define dummy::{dummy::Adder}::add(self_1: .rust_mut = "const" .rust_pointer = "reference" *dummy::Adder, a_2: int, b_3: int) : int {
       local var_0: int, var_4: int, var_5: int, var_6: int
       #node_0:
           n0:int = load &a_2

--- a/infer/src/rust/unit/RustMir2TextualTestPointers.ml
+++ b/infer/src/rust/unit/RustMir2TextualTestPointers.ml
@@ -24,12 +24,12 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, x_1: int, ref_x_2: *int, y_3: int
+      local var_0: void, x_1: int, ref_x_2: .rust_mut = "const" .rust_pointer = "reference" *int, y_3: int
       #node_0:
           store &var_0 <- null:void
           store &x_1 <- 42:int
-          store &ref_x_2 <- &x_1:*int
-          n0:*int = load &ref_x_2
+          store &ref_x_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
           n1:int = load n0
           store &y_3 <- n1:int
           store &var_0 <- null:void
@@ -58,20 +58,20 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, x_1: int, ref_1_2: *int, ref_2_3: **int, ref_3_4: ***int, y_5: int, var_6: **int, var_7: *int
+      local var_0: void, x_1: int, ref_1_2: .rust_mut = "const" .rust_pointer = "reference" *int, ref_2_3: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, ref_3_4: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, y_5: int, var_6: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, var_7: .rust_mut = "const" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &x_1 <- 42:int
-          store &ref_1_2 <- &x_1:*int
-          store &ref_2_3 <- &ref_1_2:**int
-          store &ref_3_4 <- &ref_2_3:***int
-          n0:***int = load &ref_3_4
-          n1:**int = load n0
-          store &var_6 <- n1:**int
-          n2:**int = load &var_6
-          n3:*int = load n2
-          store &var_7 <- n3:*int
-          n4:*int = load &var_7
+          store &ref_1_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          store &ref_2_3 <- &ref_1_2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+          store &ref_3_4 <- &ref_2_3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
+          n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n0
+          store &var_6 <- n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+          n2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+          n3:.rust_mut = "const" .rust_pointer = "reference" *int = load n2
+          store &var_7 <- n3:.rust_mut = "const" .rust_pointer = "reference" *int
+          n4:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
           n5:int = load n4
           store &y_5 <- n5:int
           store &var_0 <- null:void
@@ -96,13 +96,13 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, y_1: int, x_2: *int, var_3: *int
+      local var_0: void, y_1: int, x_2: .rust_mut = "mut" .rust_pointer = "pointer" *int, var_3: .rust_mut = "mut" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &y_1 <- 10:int
-          store &var_3 <- &y_1:*int
-          n0:*int = load &var_3
-          store &x_2 <- n0:*int
+          store &var_3 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+          n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
+          store &x_2 <- n0:.rust_mut = "mut" .rust_pointer = "pointer" *int
           store &var_0 <- null:void
           n1:void = load &var_0
           ret n1
@@ -125,11 +125,11 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, y_1: int, x_2: *int
+      local var_0: void, y_1: int, x_2: .rust_mut = "mut" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &y_1 <- 10:int
-          store &x_2 <- &y_1:*int
+          store &x_2 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
           store &var_0 <- null:void
           n0:void = load &var_0
           ret n0
@@ -152,13 +152,13 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, y_1: int, x_2: *int, var_3: *int
+      local var_0: void, y_1: int, x_2: .rust_mut = "const" .rust_pointer = "pointer" *int, var_3: .rust_mut = "const" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &y_1 <- 10:int
-          store &var_3 <- &y_1:*int
-          n0:*int = load &var_3
-          store &x_2 <- n0:*int
+          store &var_3 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+          store &x_2 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
           store &var_0 <- null:void
           n1:void = load &var_0
           ret n1
@@ -181,11 +181,11 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, y_1: int, x_2: *int
+      local var_0: void, y_1: int, x_2: .rust_mut = "const" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &y_1 <- 10:int
-          store &x_2 <- &y_1:*int
+          store &x_2 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
           store &var_0 <- null:void
           n0:void = load &var_0
           ret n0
@@ -209,15 +209,15 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, x_1: int, y_2: *int, var_3: *int, var_4: *int
+      local var_0: void, x_1: int, y_2: .rust_mut = "const" .rust_pointer = "reference" *int, var_3: .rust_mut = "const" .rust_pointer = "reference" *int, var_4: .rust_mut = "const" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &x_1 <- 42:int
-          store &var_4 <- &x_1:*int
-          n0:*int = load &var_4
-          store &var_3 <- n0:*int
-          n1:*int = load &var_3
-          store &y_2 <- n1:*int
+          store &var_4 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+          store &var_3 <- n0:.rust_mut = "const" .rust_pointer = "reference" *int
+          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+          store &y_2 <- n1:.rust_mut = "const" .rust_pointer = "reference" *int
           store &var_0 <- null:void
           n2:void = load &var_0
           ret n2
@@ -240,13 +240,13 @@ fn main() {
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, x_1: int, ptr_2: *int, y_3: *int
+      local var_0: void, x_1: int, ptr_2: .rust_mut = "const" .rust_pointer = "reference" *int, y_3: .rust_mut = "const" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &x_1 <- 42:int
-          store &ptr_2 <- &x_1:*int
-          n0:*int = load &ptr_2
-          store &y_3 <- n0:*int
+          store &ptr_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ptr_2
+          store &y_3 <- n0:.rust_mut = "const" .rust_pointer = "reference" *int
           store &var_0 <- null:void
           n1:void = load &var_0
           ret n1
@@ -271,12 +271,12 @@ let%expect_test "mutate_through_reference" =
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, x_1: int, ptr_2: *int
+      local var_0: void, x_1: int, ptr_2: .rust_mut = "mut" .rust_pointer = "reference" *int
       #node_0:
           store &var_0 <- null:void
           store &x_1 <- 10:int
-          store &ptr_2 <- &x_1:*int
-          n0:*int = load &ptr_2
+          store &ptr_2 <- &x_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+          n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
           store n0 <- 20:int
           store &var_0 <- null:void
           n1:void = load &var_0
@@ -301,11 +301,11 @@ let%expect_test "null_pointer" =
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, ptr_1: *int, x_2: int
+      local var_0: void, ptr_1: .rust_mut = "const" .rust_pointer = "pointer" *int, x_2: int
       #node_0:
           store &var_0 <- null:void
           n0 = core::ptr::null()
-          store &ptr_1 <- n0:*int
+          store &ptr_1 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
           jmp node_2
           .handlers node_1
 
@@ -313,7 +313,7 @@ let%expect_test "null_pointer" =
           throw "UnwindResume"
 
       #node_2:
-          n1:*int = load &ptr_1
+          n1:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
           n2:int = load n1
           store &x_2 <- n2:int
           store &var_0 <- null:void
@@ -322,13 +322,13 @@ let%expect_test "null_pointer" =
 
     }
 
-    define core::ptr::null() : *void {
-      local var_0: *void, var_1: *void
+    define core::ptr::null() : .rust_mut = "const" .rust_pointer = "pointer" *void {
+      local var_0: .rust_mut = "const" .rust_pointer = "pointer" *void, var_1: .rust_mut = "const" .rust_pointer = "pointer" *void
       #node_0:
-          store &var_1 <- __sil_cast(<*void>, 0):*void
-          n0:*void = load &var_1
-          store &var_0 <- n0:*void
-          n1:*void = load &var_0
+          store &var_1 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *void>, 0):.rust_mut = "const" .rust_pointer = "pointer" *void
+          n0:.rust_mut = "const" .rust_pointer = "pointer" *void = load &var_1
+          store &var_0 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *void
+          n1:.rust_mut = "const" .rust_pointer = "pointer" *void = load &var_0
           ret n1
 
     }
@@ -464,12 +464,12 @@ let%expect_test "box_use_after_free" =
 
     type core::marker::PhantomData::<i32> = {}
 
-    type core::ptr::non_null::NonNull::<i32> = {pointer: *int}
+    type core::ptr::non_null::NonNull::<i32> = {pointer: .rust_mut = "const" .rust_pointer = "pointer" *int}
 
     type core::ptr::unique::Unique::<i32> = {pointer: *void; _marker: core::marker::PhantomData::<i32>}
 
     define dummy::main() : void {
-      local var_0: void, ptr_1: *int, x_2: *int, var_3: *int, var_4: *int, ub_5: int, var_6: *int
+      local var_0: void, ptr_1: .rust_mut = "const" .rust_pointer = "pointer" *int, x_2: *int, var_3: .rust_mut = "const" .rust_pointer = "pointer" *int, var_4: .rust_mut = "const" .rust_pointer = "reference" *int, ub_5: int, var_6: .rust_mut = "const" .rust_pointer = "pointer" *int
       #node_0:
           store &var_0 <- null:void
           n0 = __sil_boxnew(50)
@@ -482,20 +482,20 @@ let%expect_test "box_use_after_free" =
 
       #node_2:
           n1:*void = load &x_2
-          store &var_6 <- __sil_cast(<*int>, n1):*int
-          n2:*int = load &var_6
-          store &var_4 <- n2:*int
-          n3:*int = load &var_4
-          store &var_3 <- n3:*int
-          n4:*int = load &var_3
-          store &ptr_1 <- n4:*int
+          store &var_6 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *int>, n1):.rust_mut = "const" .rust_pointer = "pointer" *int
+          n2:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
+          store &var_4 <- n2:.rust_mut = "const" .rust_pointer = "reference" *int
+          n3:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+          store &var_3 <- n3:.rust_mut = "const" .rust_pointer = "pointer" *int
+          n4:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
+          store &ptr_1 <- n4:.rust_mut = "const" .rust_pointer = "pointer" *int
           n5:*int = load &x_2
           n6 = __sil_free(n5)
           jmp node_3
           .handlers node_4
 
       #node_3:
-          n7:*int = load &ptr_1
+          n7:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
           n8:int = load n7
           store &ub_5 <- n8:int
           store &var_0 <- null:void
@@ -507,7 +507,48 @@ let%expect_test "box_use_after_free" =
 
     }
 
-    declare alloc::alloc::Global::{TraitImpl@1}::drop_in_place(*alloc::alloc::Global) : void
+    declare alloc::alloc::Global::{TraitImpl@1}::drop_in_place(.rust_mut = "mut" .rust_pointer = "pointer" *alloc::alloc::Global) : void
 
-    declare alloc::boxed::Box::{TraitImpl@2}::drop_in_place::<i32, alloc::alloc::Global>(**int) : void
+    declare alloc::boxed::Box::{TraitImpl@2}::drop_in_place::<i32, alloc::alloc::Global>(.rust_mut = "mut" .rust_pointer = "pointer" **int) : void
+    |}]
+
+
+let%expect_test "pointer_attributes" =
+  let source =
+    {|
+#[allow(unused)]
+fn main() {
+    let x = 1;
+    let mut y = 2;
+    let shared = &x;
+    let exclusive = &mut y;
+    let raw_const = &x as *const i32;
+    let raw_mut = &mut y as *mut i32;
+}
+|}
+  in
+  test source ;
+  [%expect
+    {|
+    .source_language = "Rust"
+
+    define dummy::main() : void {
+      local var_0: void, x_1: int, y_2: int, shared_3: .rust_mut = "const" .rust_pointer = "reference" *int, exclusive_4: .rust_mut = "mut" .rust_pointer = "reference" *int, raw_const_5: .rust_mut = "const" .rust_pointer = "pointer" *int, var_6: .rust_mut = "const" .rust_pointer = "reference" *int, raw_mut_7: .rust_mut = "mut" .rust_pointer = "pointer" *int, var_8: .rust_mut = "mut" .rust_pointer = "reference" *int
+      #node_0:
+          store &var_0 <- null:void
+          store &x_1 <- 1:int
+          store &y_2 <- 2:int
+          store &shared_3 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          store &exclusive_4 <- &y_2:.rust_mut = "mut" .rust_pointer = "reference" *int
+          store &var_6 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+          store &raw_const_5 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
+          store &var_8 <- &y_2:.rust_mut = "mut" .rust_pointer = "reference" *int
+          n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_8
+          store &raw_mut_7 <- n1:.rust_mut = "mut" .rust_pointer = "pointer" *int
+          store &var_0 <- null:void
+          n2:void = load &var_0
+          ret n2
+
+    }
     |}]

--- a/infer/src/rust/unit/RustMir2TextualTestRvalues.ml
+++ b/infer/src/rust/unit/RustMir2TextualTestRvalues.ml
@@ -498,10 +498,10 @@ let%expect_test "string" =
     .source_language = "Rust"
 
     define dummy::main() : void {
-      local var_0: void, hello_1: *String
+      local var_0: void, hello_1: .rust_mut = "const" .rust_pointer = "reference" *String
       #node_0:
           store &var_0 <- null:void
-          store &hello_1 <- "hello":*String
+          store &hello_1 <- "hello":.rust_mut = "const" .rust_pointer = "reference" *String
           store &var_0 <- null:void
           n0:void = load &var_0
           ret n0

--- a/infer/src/textual/Textual.ml
+++ b/infer/src/textual/Textual.ml
@@ -592,6 +592,22 @@ module Attr = struct
 
   let find_python_args {name; values} = if String.equal name "args" then Some values else None
 
+  let is_rust_reference {name; values} =
+    String.equal name "rust_pointer" && List.equal String.equal values ["reference"]
+
+
+  let is_rust_raw {name; values} =
+    String.equal name "rust_pointer" && List.equal String.equal values ["pointer"]
+
+
+  let is_rust_mut {name; values} =
+    String.equal name "rust_mut" && List.equal String.equal values ["mut"]
+
+
+  let is_rust_const {name; values} =
+    String.equal name "rust_mut" && List.equal String.equal values ["const"]
+
+
   let mk_async = mk "async"
 
   let mk_closure_wrapper = mk "closure_wrapper"
@@ -611,6 +627,14 @@ module Attr = struct
   let ptr_nonull = mk "nonnull"
 
   let ptr_nullable = mk "nullable *"
+
+  let ptr_rust_reference = {name= "rust_pointer"; values= ["reference"]; loc= Location.Unknown}
+
+  let ptr_rust_raw = {name= "rust_pointer"; values= ["pointer"]; loc= Location.Unknown}
+
+  let ptr_rust_mut = {name= "rust_mut"; values= ["mut"]; loc= Location.Unknown}
+
+  let ptr_rust_const = {name= "rust_mut"; values= ["const"]; loc= Location.Unknown}
 
   let mk_plain_name name = {name= "plain_name"; values= [name]; loc= Location.Unknown}
 

--- a/infer/src/textual/Textual.mli
+++ b/infer/src/textual/Textual.mli
@@ -229,6 +229,14 @@ module Attr : sig
 
   val is_const : t -> bool
 
+  val is_rust_reference : t -> bool
+
+  val is_rust_raw : t -> bool
+
+  val is_rust_mut : t -> bool
+
+  val is_rust_const : t -> bool
+
   val mk_python_args : string list -> t
 
   val find_python_args : t -> string list option
@@ -254,6 +262,14 @@ module Attr : sig
   val mk_weak_self_capture : t
 
   val mk_trait : t
+
+  val ptr_rust_reference : t
+
+  val ptr_rust_raw : t
+
+  val ptr_rust_mut : t
+
+  val ptr_rust_const : t
 
   val mk_plain_name : string -> t
 

--- a/infer/src/textual/TextualSil.ml
+++ b/infer/src/textual/TextualSil.ml
@@ -252,8 +252,12 @@ module TypBridge = struct
   open Typ
 
   let rec to_sil lang ?(attrs = []) (typ : t) : SilTyp.t =
-    let is_const = List.exists attrs ~f:Textual.Attr.is_const in
-    let quals = SilTyp.mk_type_quals ~is_const () in
+    let ptr_attrs = match typ with Ptr (_, a) -> a | _ -> [] in
+    let has_rust_ref = List.exists ptr_attrs ~f:Textual.Attr.is_rust_reference in
+    let has_rust_const = List.exists ptr_attrs ~f:Textual.Attr.is_rust_const in
+    let is_const = List.exists attrs ~f:Textual.Attr.is_const || has_rust_const in
+    let is_reference = has_rust_ref in
+    let quals = SilTyp.mk_type_quals ~is_const ~is_reference () in
     let desc : SilTyp.desc =
       match typ with
       | Int ->

--- a/infer/tests/codetoanalyze/rust/sil/basic_deref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_deref.rs.ullbc.sil
@@ -7,12 +7,12 @@
 .source_language = "Rust"
 
 define basic_deref::main() : void {
-  local var_0: void, x_1: int, ref_x_2: *int, y_3: int
+  local var_0: void, x_1: int, ref_x_2: .rust_mut = "const" .rust_pointer = "reference" *int, y_3: int
   #node_0:
       store &var_0 <- null:void
       store &x_1 <- 42:int
-      store &ref_x_2 <- &x_1:*int
-      n0:*int = load &ref_x_2
+      store &ref_x_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+      n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
       n1:int = load n0
       store &y_3 <- n1:int
       store &var_0 <- null:void

--- a/infer/tests/codetoanalyze/rust/sil/basic_mut_raw_ptr.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_mut_raw_ptr.rs.ullbc.sil
@@ -7,13 +7,13 @@
 .source_language = "Rust"
 
 define basic_mut_raw_ptr::main() : void {
-  local var_0: void, y_1: int, x_2: *int, var_3: *int
+  local var_0: void, y_1: int, x_2: .rust_mut = "mut" .rust_pointer = "pointer" *int, var_3: .rust_mut = "mut" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &y_1 <- 10:int
-      store &var_3 <- &y_1:*int
-      n0:*int = load &var_3
-      store &x_2 <- n0:*int
+      store &var_3 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+      n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
+      store &x_2 <- n0:.rust_mut = "mut" .rust_pointer = "pointer" *int
       store &var_0 <- null:void
       n1:void = load &var_0
       ret n1

--- a/infer/tests/codetoanalyze/rust/sil/basic_mut_ref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_mut_ref.rs.ullbc.sil
@@ -7,11 +7,11 @@
 .source_language = "Rust"
 
 define basic_mut_ref::main() : void {
-  local var_0: void, y_1: int, x_2: *int
+  local var_0: void, y_1: int, x_2: .rust_mut = "mut" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &y_1 <- 10:int
-      store &x_2 <- &y_1:*int
+      store &x_2 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
       store &var_0 <- null:void
       n0:void = load &var_0
       ret n0

--- a/infer/tests/codetoanalyze/rust/sil/basic_raw_ptr.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_raw_ptr.rs.ullbc.sil
@@ -7,13 +7,13 @@
 .source_language = "Rust"
 
 define basic_raw_ptr::main() : void {
-  local var_0: void, y_1: int, x_2: *int, var_3: *int
+  local var_0: void, y_1: int, x_2: .rust_mut = "const" .rust_pointer = "pointer" *int, var_3: .rust_mut = "const" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &y_1 <- 10:int
-      store &var_3 <- &y_1:*int
-      n0:*int = load &var_3
-      store &x_2 <- n0:*int
+      store &var_3 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
+      n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+      store &x_2 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
       store &var_0 <- null:void
       n1:void = load &var_0
       ret n1

--- a/infer/tests/codetoanalyze/rust/sil/basic_ref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_ref.rs.ullbc.sil
@@ -7,11 +7,11 @@
 .source_language = "Rust"
 
 define basic_ref::main() : void {
-  local var_0: void, y_1: int, x_2: *int
+  local var_0: void, y_1: int, x_2: .rust_mut = "const" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &y_1 <- 10:int
-      store &x_2 <- &y_1:*int
+      store &x_2 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
       store &var_0 <- null:void
       n0:void = load &var_0
       ret n0

--- a/infer/tests/codetoanalyze/rust/sil/box_free.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/box_free.rs.ullbc.sil
@@ -9,7 +9,7 @@
 type alloc::alloc::Global = {}
 
 define box_free::main() : void {
-  local var_0: void, ptr_1: *int, x_2: *int, var_3: *int, var_4: *int, ub_5: int, var_6: *int
+  local var_0: void, ptr_1: .rust_mut = "const" .rust_pointer = "pointer" *int, x_2: *int, var_3: .rust_mut = "const" .rust_pointer = "pointer" *int, var_4: .rust_mut = "const" .rust_pointer = "reference" *int, ub_5: int, var_6: .rust_mut = "const" .rust_pointer = "pointer" *int
   #node_0:
       store &var_0 <- null:void
       n0 = __sil_boxnew(50)
@@ -22,20 +22,20 @@ define box_free::main() : void {
       
   #node_2:
       n1:*int = load &x_2
-      store &var_6 <- __sil_cast(<*int>, n1):*int
-      n2:*int = load &var_6
-      store &var_4 <- n2:*int
-      n3:*int = load &var_4
-      store &var_3 <- n3:*int
-      n4:*int = load &var_3
-      store &ptr_1 <- n4:*int
+      store &var_6 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *int>, n1):.rust_mut = "const" .rust_pointer = "pointer" *int
+      n2:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
+      store &var_4 <- n2:.rust_mut = "const" .rust_pointer = "reference" *int
+      n3:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+      store &var_3 <- n3:.rust_mut = "const" .rust_pointer = "pointer" *int
+      n4:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
+      store &ptr_1 <- n4:.rust_mut = "const" .rust_pointer = "pointer" *int
       n5:*int = load &x_2
       n6 = __sil_free(n5)
       jmp node_3
       .handlers node_4
       
   #node_3:
-      n7:*int = load &ptr_1
+      n7:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
       n8:int = load n7
       store &ub_5 <- n8:int
       store &var_0 <- null:void

--- a/infer/tests/codetoanalyze/rust/sil/deref_multiple.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/deref_multiple.rs.ullbc.sil
@@ -7,20 +7,20 @@
 .source_language = "Rust"
 
 define deref_multiple::main() : void {
-  local var_0: void, x_1: int, ref_1_2: *int, ref_2_3: **int, ref_3_4: ***int, y_5: int, var_6: **int, var_7: *int
+  local var_0: void, x_1: int, ref_1_2: .rust_mut = "const" .rust_pointer = "reference" *int, ref_2_3: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, ref_3_4: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, y_5: int, var_6: .rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int, var_7: .rust_mut = "const" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &x_1 <- 42:int
-      store &ref_1_2 <- &x_1:*int
-      store &ref_2_3 <- &ref_1_2:**int
-      store &ref_3_4 <- &ref_2_3:***int
-      n0:***int = load &ref_3_4
-      n1:**int = load n0
-      store &var_6 <- n1:**int
-      n2:**int = load &var_6
-      n3:*int = load n2
-      store &var_7 <- n3:*int
-      n4:*int = load &var_7
+      store &ref_1_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+      store &ref_2_3 <- &ref_1_2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+      store &ref_3_4 <- &ref_2_3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+      n0:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
+      n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n0
+      store &var_6 <- n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+      n2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+      n3:.rust_mut = "const" .rust_pointer = "reference" *int = load n2
+      store &var_7 <- n3:.rust_mut = "const" .rust_pointer = "reference" *int
+      n4:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
       n5:int = load n4
       store &y_5 <- n5:int
       store &var_0 <- null:void

--- a/infer/tests/codetoanalyze/rust/sil/empty_struct.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/empty_struct.rs.ullbc.sil
@@ -9,11 +9,11 @@
 type empty_struct::Adder = {}
 
 define empty_struct::main() : void {
-  local var_0: void, adder_1: empty_struct::Adder, three_2: int, var_3: *empty_struct::Adder
+  local var_0: void, adder_1: empty_struct::Adder, three_2: int, var_3: .rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder
   #node_0:
       store &var_0 <- null:void
-      store &var_3 <- &adder_1:*empty_struct::Adder
-      n0:*empty_struct::Adder = load &var_3
+      store &var_3 <- &adder_1:.rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder
+      n0:.rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder = load &var_3
       n1 = empty_struct::{empty_struct::Adder}::add(n0, 1, 2)
       store &three_2 <- n1:int
       jmp node_2
@@ -29,7 +29,7 @@ define empty_struct::main() : void {
       
 }
 
-define empty_struct::{empty_struct::Adder}::add(self_1: *empty_struct::Adder, a_2: int, b_3: int) : int {
+define empty_struct::{empty_struct::Adder}::add(self_1: .rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder, a_2: int, b_3: int) : int {
   local var_0: int, var_4: int, var_5: int, var_6: int
   #node_0:
       n0:int = load &a_2

--- a/infer/tests/codetoanalyze/rust/sil/mutate_through_reference.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/mutate_through_reference.rs.ullbc.sil
@@ -7,12 +7,12 @@
 .source_language = "Rust"
 
 define mutate_through_reference::main() : void {
-  local var_0: void, x_1: int, ptr_2: *int
+  local var_0: void, x_1: int, ptr_2: .rust_mut = "mut" .rust_pointer = "reference" *int
   #node_0:
       store &var_0 <- null:void
       store &x_1 <- 10:int
-      store &ptr_2 <- &x_1:*int
-      n0:*int = load &ptr_2
+      store &ptr_2 <- &x_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+      n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
       store n0 <- 20:int
       store &var_0 <- null:void
       n1:void = load &var_0

--- a/infer/tests/codetoanalyze/rust/sil/null.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/null.rs.ullbc.sil
@@ -7,11 +7,11 @@
 .source_language = "Rust"
 
 define null::main() : void {
-  local var_0: void, ptr_1: *int, x_2: int
+  local var_0: void, ptr_1: .rust_mut = "const" .rust_pointer = "pointer" *int, x_2: int
   #node_0:
       store &var_0 <- null:void
       n0 = core::ptr::null()
-      store &ptr_1 <- n0:*int
+      store &ptr_1 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
       jmp node_2
       .handlers node_1
       
@@ -19,7 +19,7 @@ define null::main() : void {
       throw "UnwindResume"
       
   #node_2:
-      n1:*int = load &ptr_1
+      n1:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
       n2:int = load n1
       store &x_2 <- n2:int
       store &var_0 <- null:void
@@ -28,13 +28,13 @@ define null::main() : void {
       
 }
 
-define core::ptr::null() : *void {
-  local var_0: *void, var_1: *void
+define core::ptr::null() : .rust_mut = "const" .rust_pointer = "pointer" *void {
+  local var_0: .rust_mut = "const" .rust_pointer = "pointer" *void, var_1: .rust_mut = "const" .rust_pointer = "pointer" *void
   #node_0:
-      store &var_1 <- __sil_cast(<*void>, 0):*void
-      n0:*void = load &var_1
-      store &var_0 <- n0:*void
-      n1:*void = load &var_0
+      store &var_1 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *void>, 0):.rust_mut = "const" .rust_pointer = "pointer" *void
+      n0:.rust_mut = "const" .rust_pointer = "pointer" *void = load &var_1
+      store &var_0 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *void
+      n1:.rust_mut = "const" .rust_pointer = "pointer" *void = load &var_0
       ret n1
       
 }


### PR DESCRIPTION
First step towards a Tree Borrows checker for the Rust frontend.

Charon already distinguishes references (&/&mut) from raw pointers (*const/*mut), and mutable from const, but that information was discarded during translation. This PR preserves it: pointer types now carry .rust_pointer and .rust_mut attributes in Textual, and the Textual→SIL bridge maps them onto the SIL type_quals (is_reference, is_const), so later analyses can tell a &mut from a *mut from a &.

This is a frontend translation only,  no analysis changes.

