### PR TITLE
[rust][TreeBorrows] Add Tree Borrows state in the Pulse abstract state

### DIFF
--- a/infer/src/pulse/Pulse.ml
+++ b/infer/src/pulse/Pulse.ml
@@ -1372,6 +1372,16 @@ module PulseTransferFunctions = struct
               PulseTransitiveAccessChecker.record_load rhs_exp loc astates
             else astates
           in
+          let astates =
+            if Config.is_checker_enabled TreeBorrows then
+              List.map astates ~f:(function
+                | ContinueProgram astate ->
+                    ContinueProgram
+                      (PulseTreeBorrowsOperations.exec_load ~id:lhs_id ~e:rhs_exp ~typ ~loc astate)
+                | other ->
+                    other )
+            else astates
+          in
           (List.take astates limit, path, non_disj)
       | Store {e1= lhs_exp; e2= rhs_exp; loc; typ} ->
           (* [*lhs_exp := rhs_exp] *)
@@ -1427,6 +1437,11 @@ module PulseTransferFunctions = struct
             let astate =
               if Topl.is_active () then
                 topl_store_step tenv path loc ~lhs:lhs_exp ~rhs:rhs_exp astate
+              else astate
+            in
+            let astate =
+              if Config.is_checker_enabled TreeBorrows then
+                PulseTreeBorrowsOperations.exec_store ~lhs:lhs_exp ~rhs:rhs_exp ~typ ~loc astate
               else astate
             in
             match lhs_exp with

--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -78,6 +78,7 @@ type t =
   ; path_condition: Formula.t
   ; decompiler: (Decompiler.t[@yojson.opaque] [@ignore])
   ; topl: (PulseTopl.state[@yojson.opaque])
+  ; tree_borrows: (PulseTreeBorrows.state[@yojson.opaque])
   ; need_dynamic_type_specialization: (AbstractValue.Set.t[@yojson.opaque])
   ; transitive_info: (TransitiveInfo.t[@yojson.opaque])
   ; recursive_calls: (PulseMutualRecursion.Set.t[@yojson.opaque])
@@ -100,6 +101,7 @@ let pp_ ~is_summary f
      ; need_dynamic_type_specialization
      ; transitive_info
      ; topl
+     ; tree_borrows
      ; recursive_calls
      ; loop_header_info
      ; loop_invariant_under_inference
@@ -129,11 +131,13 @@ let pp_ ~is_summary f
      loop_header_info=%a@;\
      %tunknown_values=%b@;\
      skipped_calls=%a@;\
-     Topl=%a@]"
+     Topl=%a@;\
+     TreeBorrows=%a@]"
     Formula.pp path_condition pp_pre_post pp_decompiler AbstractValue.Set.pp
     need_dynamic_type_specialization TransitiveInfo.pp transitive_info PulseMutualRecursion.Set.pp
     recursive_calls PulseLoopHeaderInfo.pp loop_header_info pp_loop_invariant_under_inference
-    unknown_values SkippedCalls.pp skipped_calls PulseTopl.pp_state topl
+    unknown_values SkippedCalls.pp skipped_calls PulseTopl.pp_state topl PulseTreeBorrows.pp
+    tree_borrows
 
 
 let pp = pp_ ~is_summary:false
@@ -1543,6 +1547,7 @@ let empty =
   ; decompiler= Decompiler.empty
   ; need_dynamic_type_specialization= AbstractValue.Set.empty
   ; topl= PulseTopl.start () (* TODO: this defeats the laziness of Topl.automaton *)
+  ; tree_borrows= PulseTreeBorrows.start ()
   ; transitive_info= TransitiveInfo.bottom
   ; recursive_calls= PulseMutualRecursion.Set.empty
   ; loop_header_info= PulseLoopHeaderInfo.empty
@@ -1560,6 +1565,7 @@ let mk_join_state ~pre:(stack_pre, heap_pre, attrs_pre) ~post:(stack_post, heap_
   ; decompiler
   ; need_dynamic_type_specialization
   ; topl
+  ; tree_borrows= PulseTreeBorrows.start ()
   ; transitive_info
   ; recursive_calls
   ; loop_header_info

--- a/infer/src/pulse/PulseAbductiveDomain.mli
+++ b/infer/src/pulse/PulseAbductiveDomain.mli
@@ -65,6 +65,8 @@ type t = private
   ; decompiler: Decompiler.t
   ; topl: PulseTopl.state
         (** state at of the Topl monitor at the current program point, when Topl is enabled *)
+  ; tree_borrows: PulseTreeBorrows.state
+        (** state of the Tree Borrows checker at the current program point, when it is enabled *)
   ; need_dynamic_type_specialization: AbstractValue.Set.t
         (** a set of abstract values that are used as receiver of method calls in the instructions
             reached so far *)

--- a/infer/src/pulse/PulseTreeBorrows.ml
+++ b/infer/src/pulse/PulseTreeBorrows.ml
@@ -1,0 +1,15 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+module F = Format
+
+type state = unit [@@deriving compare, equal]
+
+let start () = ()
+
+let pp fmt () = F.pp_print_string fmt "()"

--- a/infer/src/pulse/PulseTreeBorrows.mli
+++ b/infer/src/pulse/PulseTreeBorrows.mli
@@ -1,0 +1,16 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+module F = Format
+
+(** Abstract state of the Tree Borrows checker. *)
+type state [@@deriving compare, equal]
+
+val start : unit -> state
+
+val pp : F.formatter -> state -> unit

--- a/infer/src/pulse/PulseTreeBorrowsOperations.ml
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.ml
@@ -1,0 +1,13 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+module AbductiveDomain = PulseAbductiveDomain
+
+let exec_load ~id:_ ~e:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate
+
+let exec_store ~lhs:_ ~rhs:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate

--- a/infer/src/pulse/PulseTreeBorrowsOperations.mli
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.mli
@@ -1,0 +1,15 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+module AbductiveDomain = PulseAbductiveDomain
+
+val exec_load :
+  id:Ident.t -> e:Exp.t -> typ:Typ.t -> loc:Location.t -> AbductiveDomain.t -> AbductiveDomain.t
+
+val exec_store :
+  lhs:Exp.t -> rhs:Exp.t -> typ:Typ.t -> loc:Location.t -> AbductiveDomain.t -> AbductiveDomain.t


### PR DESCRIPTION
Adds the state for the Tree Borrows checker. It does not do any analysis yet.

A minimal PulseTreeBorrows.state is added as a new field of the Pulse abstract state. The Load and Store transfer functions call the new PulseTreeBorrowsOperations hooks, but only when the checker is enabled. These do nothing for now. The following PRs will add the Tree Borrows logic.