### PR TITLE
[rust][TreeBorrows] Emit a retag builtin when references are created

### DIFF
--- a/infer/src/absint/ProcnameDispatcher.ml
+++ b/infer/src/absint/ProcnameDispatcher.ml
@@ -766,7 +766,7 @@ module Call = struct
         match (procname : Procname.t) with
         | ObjC_Cpp objc_cpp ->
             on_objc_cpp context objc_cpp args
-        | C c ->
+        | C c | Rust c ->
             on_c context c args
         | Hack hack ->
             on_hack context hack args

--- a/infer/src/pulse/PulseModels.ml
+++ b/infer/src/pulse/PulseModels.ml
@@ -18,7 +18,7 @@ module ProcNameDispatcher = struct
       @ PulseModelsErlang.matchers @ PulseModelsGenericArrayBackedCollection.matchers
       @ PulseModelsHack.matchers @ PulseModelsJava.matchers @ PulseModelsObjC.matchers
       @ PulseModelsOptional.matchers @ PulseModelsSmartPointers.matchers @ PulseModelsLocks.matchers
-      @ Basic.matchers )
+      @ PulseModelsRust.matchers @ Basic.matchers )
 end
 
 let dispatch tenv proc_name args =

--- a/infer/src/pulse/PulseModelsRust.ml
+++ b/infer/src/pulse/PulseModelsRust.ml
@@ -1,0 +1,13 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+open PulseModelsImport
+
+let matchers : matcher list =
+  let open ProcnameDispatcher.Call in
+  [-"__rust_retag" &--> Basic.skip |> with_non_disj]

--- a/infer/src/pulse/PulseModelsRust.mli
+++ b/infer/src/pulse/PulseModelsRust.mli
@@ -1,0 +1,11 @@
+(*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+open! IStd
+open PulseModelsImport
+
+val matchers : matcher list

--- a/infer/src/rust/RustMir2Textual.ml
+++ b/infer/src/rust/RustMir2Textual.ml
@@ -778,6 +778,25 @@ let mk_field_store_instrs_from_rvalues ~loc crate lexp enclosing_class place_map
   |> List.mapi ~f:(mk_field_store_instr_from_rvalue ~loc crate lexp enclosing_class place_map)
 
 
+let mk_retag_instrs ~loc (rhs : Charon.Generated_Expressions.rvalue) ~(dst : Textual.Exp.t)
+    ~(borrowed : Textual.Exp.t) : Textual.Instr.t list =
+  let mk_retag ~is_mut =
+    let bool_exp b = Textual.Exp.Const (Textual.Const.Int (if b then Z.one else Z.zero)) in
+    let call =
+      Textual.Exp.call_non_virtual Textual.ProcDecl.rust_retag_name [dst; borrowed; bool_exp is_mut]
+    in
+    [Textual.Instr.Let {id= None; exp= call; loc}]
+  in
+  match rhs with
+  | RvRef (_, borrow_kind, _) ->
+      let is_mut =
+        match borrow_kind with BMut | BTwoPhaseMut | BUniqueImmutable -> true | _ -> false
+      in
+      mk_retag ~is_mut
+  | _ ->
+      []
+
+
 let mk_instr crate (place_map : place_map_ty) (statement : Charon.Generated_UllbcAst.statement) :
     Textual.Instr.t list =
   let loc = location_from_span statement.span in
@@ -851,7 +870,7 @@ let mk_instr crate (place_map : place_map_ty) (statement : Charon.Generated_Ullb
       let exp1 = mk_exp_from_place ~loc crate place_map lhs in
       let exp2, typ = mk_exp_from_rvalue ~loc crate rhs place_map in
       let store_instr = Textual.Instr.Store {exp1; typ= Some typ; exp2; loc} in
-      [store_instr]
+      store_instr :: mk_retag_instrs ~loc rhs ~dst:exp1 ~borrowed:exp2
   | StorageDead _ ->
       []
   | StorageLive _ ->

--- a/infer/src/rust/unit/RustMir2TextualTestAggregates.ml
+++ b/infer/src/rust/unit/RustMir2TextualTestAggregates.ml
@@ -268,9 +268,10 @@ fn main() {
       #node_0:
           store &var_0 <- null:void
           store &var_3 <- &adder_1:.rust_mut = "const" .rust_pointer = "reference" *dummy::Adder
-          n0:.rust_mut = "const" .rust_pointer = "reference" *dummy::Adder = load &var_3
-          n1 = dummy::{dummy::Adder}::add(n0, 1, 2)
-          store &three_2 <- n1:int
+          n0 = __rust_retag(&var_3, &adder_1, 0)
+          n1:.rust_mut = "const" .rust_pointer = "reference" *dummy::Adder = load &var_3
+          n2 = dummy::{dummy::Adder}::add(n1, 1, 2)
+          store &three_2 <- n2:int
           jmp node_2
           .handlers node_1
 
@@ -279,8 +280,8 @@ fn main() {
 
       #node_2:
           store &var_0 <- null:void
-          n2:void = load &var_0
-          ret n2
+          n3:void = load &var_0
+          ret n3
 
     }
 

--- a/infer/src/rust/unit/RustMir2TextualTestPointers.ml
+++ b/infer/src/rust/unit/RustMir2TextualTestPointers.ml
@@ -29,12 +29,13 @@ fn main() {
           store &var_0 <- null:void
           store &x_1 <- 42:int
           store &ref_x_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
-          n1:int = load n0
-          store &y_3 <- n1:int
+          n0 = __rust_retag(&ref_x_2, &x_1, 0)
+          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
+          n2:int = load n1
+          store &y_3 <- n2:int
           store &var_0 <- null:void
-          n2:void = load &var_0
-          ret n2
+          n3:void = load &var_0
+          ret n3
 
     }
     |}]
@@ -63,20 +64,23 @@ fn main() {
           store &var_0 <- null:void
           store &x_1 <- 42:int
           store &ref_1_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&ref_1_2, &x_1, 0)
           store &ref_2_3 <- &ref_1_2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+          n1 = __rust_retag(&ref_2_3, &ref_1_2, 0)
           store &ref_3_4 <- &ref_2_3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
-          n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n0
-          store &var_6 <- n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
-          n2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
-          n3:.rust_mut = "const" .rust_pointer = "reference" *int = load n2
-          store &var_7 <- n3:.rust_mut = "const" .rust_pointer = "reference" *int
-          n4:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
-          n5:int = load n4
-          store &y_5 <- n5:int
+          n2 = __rust_retag(&ref_3_4, &ref_2_3, 0)
+          n3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
+          n4:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n3
+          store &var_6 <- n4:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+          n5:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+          n6:.rust_mut = "const" .rust_pointer = "reference" *int = load n5
+          store &var_7 <- n6:.rust_mut = "const" .rust_pointer = "reference" *int
+          n7:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
+          n8:int = load n7
+          store &y_5 <- n8:int
           store &var_0 <- null:void
-          n6:void = load &var_0
-          ret n6
+          n9:void = load &var_0
+          ret n9
 
     }
     |}]
@@ -101,11 +105,12 @@ fn main() {
           store &var_0 <- null:void
           store &y_1 <- 10:int
           store &var_3 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
-          n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
-          store &x_2 <- n0:.rust_mut = "mut" .rust_pointer = "pointer" *int
+          n0 = __rust_retag(&var_3, &y_1, 1)
+          n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
+          store &x_2 <- n1:.rust_mut = "mut" .rust_pointer = "pointer" *int
           store &var_0 <- null:void
-          n1:void = load &var_0
-          ret n1
+          n2:void = load &var_0
+          ret n2
 
     }
     |}]
@@ -130,9 +135,10 @@ fn main() {
           store &var_0 <- null:void
           store &y_1 <- 10:int
           store &x_2 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&x_2, &y_1, 1)
           store &var_0 <- null:void
-          n0:void = load &var_0
-          ret n0
+          n1:void = load &var_0
+          ret n1
 
     }
     |}]
@@ -157,11 +163,12 @@ fn main() {
           store &var_0 <- null:void
           store &y_1 <- 10:int
           store &var_3 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
-          store &x_2 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
+          n0 = __rust_retag(&var_3, &y_1, 0)
+          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+          store &x_2 <- n1:.rust_mut = "const" .rust_pointer = "pointer" *int
           store &var_0 <- null:void
-          n1:void = load &var_0
-          ret n1
+          n2:void = load &var_0
+          ret n2
 
     }
     |}]
@@ -186,9 +193,10 @@ fn main() {
           store &var_0 <- null:void
           store &y_1 <- 10:int
           store &x_2 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&x_2, &y_1, 0)
           store &var_0 <- null:void
-          n0:void = load &var_0
-          ret n0
+          n1:void = load &var_0
+          ret n1
 
     }
     |}]
@@ -214,13 +222,18 @@ fn main() {
           store &var_0 <- null:void
           store &x_1 <- 42:int
           store &var_4 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
-          store &var_3 <- n0:.rust_mut = "const" .rust_pointer = "reference" *int
-          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
-          store &y_2 <- n1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&var_4, &x_1, 0)
+          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+          store &var_3 <- n1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n2:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+          n3 = __rust_retag(&var_3, n2, 0)
+          n4:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+          store &y_2 <- n4:.rust_mut = "const" .rust_pointer = "reference" *int
+          n5:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+          n6 = __rust_retag(&y_2, n5, 0)
           store &var_0 <- null:void
-          n2:void = load &var_0
-          ret n2
+          n7:void = load &var_0
+          ret n7
 
     }
     |}]
@@ -245,11 +258,14 @@ fn main() {
           store &var_0 <- null:void
           store &x_1 <- 42:int
           store &ptr_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ptr_2
-          store &y_3 <- n0:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&ptr_2, &x_1, 0)
+          n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &ptr_2
+          store &y_3 <- n1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n2:.rust_mut = "const" .rust_pointer = "reference" *int = load &ptr_2
+          n3 = __rust_retag(&y_3, n2, 0)
           store &var_0 <- null:void
-          n1:void = load &var_0
-          ret n1
+          n4:void = load &var_0
+          ret n4
 
     }
     |}]
@@ -276,11 +292,12 @@ let%expect_test "mutate_through_reference" =
           store &var_0 <- null:void
           store &x_1 <- 10:int
           store &ptr_2 <- &x_1:.rust_mut = "mut" .rust_pointer = "reference" *int
-          n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
-          store n0 <- 20:int
+          n0 = __rust_retag(&ptr_2, &x_1, 1)
+          n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
+          store n1 <- 20:int
           store &var_0 <- null:void
-          n1:void = load &var_0
-          ret n1
+          n2:void = load &var_0
+          ret n2
 
     }
     |}]
@@ -485,22 +502,24 @@ let%expect_test "box_use_after_free" =
           store &var_6 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *int>, n1):.rust_mut = "const" .rust_pointer = "pointer" *int
           n2:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
           store &var_4 <- n2:.rust_mut = "const" .rust_pointer = "reference" *int
-          n3:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
-          store &var_3 <- n3:.rust_mut = "const" .rust_pointer = "pointer" *int
-          n4:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
-          store &ptr_1 <- n4:.rust_mut = "const" .rust_pointer = "pointer" *int
-          n5:*int = load &x_2
-          n6 = __sil_free(n5)
+          n3:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
+          n4 = __rust_retag(&var_4, n3, 0)
+          n5:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+          store &var_3 <- n5:.rust_mut = "const" .rust_pointer = "pointer" *int
+          n6:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
+          store &ptr_1 <- n6:.rust_mut = "const" .rust_pointer = "pointer" *int
+          n7:*int = load &x_2
+          n8 = __sil_free(n7)
           jmp node_3
           .handlers node_4
 
       #node_3:
-          n7:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
-          n8:int = load n7
-          store &ub_5 <- n8:int
+          n9:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
+          n10:int = load n9
+          store &ub_5 <- n10:int
           store &var_0 <- null:void
-          n9:void = load &var_0
-          ret n9
+          n11:void = load &var_0
+          ret n11
 
       #node_4:
           throw "UnwindResume"
@@ -539,16 +558,20 @@ fn main() {
           store &x_1 <- 1:int
           store &y_2 <- 2:int
           store &shared_3 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+          n0 = __rust_retag(&shared_3, &x_1, 0)
           store &exclusive_4 <- &y_2:.rust_mut = "mut" .rust_pointer = "reference" *int
+          n1 = __rust_retag(&exclusive_4, &y_2, 1)
           store &var_6 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
-          n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
-          store &raw_const_5 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
+          n2 = __rust_retag(&var_6, &x_1, 0)
+          n3:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+          store &raw_const_5 <- n3:.rust_mut = "const" .rust_pointer = "pointer" *int
           store &var_8 <- &y_2:.rust_mut = "mut" .rust_pointer = "reference" *int
-          n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_8
-          store &raw_mut_7 <- n1:.rust_mut = "mut" .rust_pointer = "pointer" *int
+          n4 = __rust_retag(&var_8, &y_2, 1)
+          n5:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_8
+          store &raw_mut_7 <- n5:.rust_mut = "mut" .rust_pointer = "pointer" *int
           store &var_0 <- null:void
-          n2:void = load &var_0
-          ret n2
+          n6:void = load &var_0
+          ret n6
 
     }
     |}]

--- a/infer/src/textual/Textual.ml
+++ b/infer/src/textual/Textual.ml
@@ -212,6 +212,8 @@ let builtin_boxnew = "__sil_boxnew"
 
 let builtin_boxdrop = "__sil_boxdrop"
 
+let builtin_rust_retag = "__rust_retag"
+
 module BaseTypeName : sig
   include NAME
 
@@ -904,6 +906,8 @@ module ProcDecl = struct
 
   let boxdrop_name = make_toplevel_name builtin_boxdrop Location.Unknown
 
+  let rust_retag_name = make_toplevel_name builtin_rust_retag Location.Unknown
+
   let unop_table : (Unop.t * string) list =
     [(Neg, "__sil_neg"); (BNot, "__sil_bnot"); (LNot, "__sil_lnot")]
 
@@ -1103,7 +1107,9 @@ module ProcDecl = struct
     [builtin_assert_fail; builtin_swift_alloc; builtin_objc_alloc] @ unop_builtins @ binop_builtins
 
 
-  let builtins_rust = [builtin_free; builtin_malloc; builtin_boxnew; builtin_boxdrop]
+  let builtins_rust =
+    [builtin_free; builtin_malloc; builtin_boxnew; builtin_boxdrop; builtin_rust_retag]
+
 
   let is_builtin (proc : QualifiedProcName.t) lang =
     match lang with

--- a/infer/src/textual/Textual.mli
+++ b/infer/src/textual/Textual.mli
@@ -449,6 +449,8 @@ module ProcDecl : sig
 
   val boxdrop_name : QualifiedProcName.t
 
+  val rust_retag_name : QualifiedProcName.t
+
   val is_allocate_array_builtin : QualifiedProcName.t -> bool
 
   val is_get_lazy_class_builtin : QualifiedProcName.t -> bool

--- a/infer/tests/codetoanalyze/rust/sil/basic_deref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_deref.rs.ullbc.sil
@@ -12,12 +12,13 @@ define basic_deref::main() : void {
       store &var_0 <- null:void
       store &x_1 <- 42:int
       store &ref_x_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
-      n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
-      n1:int = load n0
-      store &y_3 <- n1:int
+      n0 = __rust_retag(&ref_x_2, &x_1, 0)
+      n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_x_2
+      n2:int = load n1
+      store &y_3 <- n2:int
       store &var_0 <- null:void
-      n2:void = load &var_0
-      ret n2
+      n3:void = load &var_0
+      ret n3
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/basic_mut_raw_ptr.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_mut_raw_ptr.rs.ullbc.sil
@@ -12,11 +12,12 @@ define basic_mut_raw_ptr::main() : void {
       store &var_0 <- null:void
       store &y_1 <- 10:int
       store &var_3 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
-      n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
-      store &x_2 <- n0:.rust_mut = "mut" .rust_pointer = "pointer" *int
+      n0 = __rust_retag(&var_3, &y_1, 1)
+      n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &var_3
+      store &x_2 <- n1:.rust_mut = "mut" .rust_pointer = "pointer" *int
       store &var_0 <- null:void
-      n1:void = load &var_0
-      ret n1
+      n2:void = load &var_0
+      ret n2
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/basic_mut_ref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_mut_ref.rs.ullbc.sil
@@ -12,9 +12,10 @@ define basic_mut_ref::main() : void {
       store &var_0 <- null:void
       store &y_1 <- 10:int
       store &x_2 <- &y_1:.rust_mut = "mut" .rust_pointer = "reference" *int
+      n0 = __rust_retag(&x_2, &y_1, 1)
       store &var_0 <- null:void
-      n0:void = load &var_0
-      ret n0
+      n1:void = load &var_0
+      ret n1
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/basic_raw_ptr.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_raw_ptr.rs.ullbc.sil
@@ -12,11 +12,12 @@ define basic_raw_ptr::main() : void {
       store &var_0 <- null:void
       store &y_1 <- 10:int
       store &var_3 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
-      n0:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
-      store &x_2 <- n0:.rust_mut = "const" .rust_pointer = "pointer" *int
+      n0 = __rust_retag(&var_3, &y_1, 0)
+      n1:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_3
+      store &x_2 <- n1:.rust_mut = "const" .rust_pointer = "pointer" *int
       store &var_0 <- null:void
-      n1:void = load &var_0
-      ret n1
+      n2:void = load &var_0
+      ret n2
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/basic_ref.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/basic_ref.rs.ullbc.sil
@@ -12,9 +12,10 @@ define basic_ref::main() : void {
       store &var_0 <- null:void
       store &y_1 <- 10:int
       store &x_2 <- &y_1:.rust_mut = "const" .rust_pointer = "reference" *int
+      n0 = __rust_retag(&x_2, &y_1, 0)
       store &var_0 <- null:void
-      n0:void = load &var_0
-      ret n0
+      n1:void = load &var_0
+      ret n1
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/box_free.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/box_free.rs.ullbc.sil
@@ -25,22 +25,24 @@ define box_free::main() : void {
       store &var_6 <- __sil_cast(<.rust_mut = "const" .rust_pointer = "pointer" *int>, n1):.rust_mut = "const" .rust_pointer = "pointer" *int
       n2:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
       store &var_4 <- n2:.rust_mut = "const" .rust_pointer = "reference" *int
-      n3:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
-      store &var_3 <- n3:.rust_mut = "const" .rust_pointer = "pointer" *int
-      n4:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
-      store &ptr_1 <- n4:.rust_mut = "const" .rust_pointer = "pointer" *int
-      n5:*int = load &x_2
-      n6 = __sil_free(n5)
+      n3:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_6
+      n4 = __rust_retag(&var_4, n3, 0)
+      n5:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_4
+      store &var_3 <- n5:.rust_mut = "const" .rust_pointer = "pointer" *int
+      n6:.rust_mut = "const" .rust_pointer = "pointer" *int = load &var_3
+      store &ptr_1 <- n6:.rust_mut = "const" .rust_pointer = "pointer" *int
+      n7:*int = load &x_2
+      n8 = __sil_free(n7)
       jmp node_3
       .handlers node_4
       
   #node_3:
-      n7:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
-      n8:int = load n7
-      store &ub_5 <- n8:int
+      n9:.rust_mut = "const" .rust_pointer = "pointer" *int = load &ptr_1
+      n10:int = load n9
+      store &ub_5 <- n10:int
       store &var_0 <- null:void
-      n9:void = load &var_0
-      ret n9
+      n11:void = load &var_0
+      ret n11
       
   #node_4:
       throw "UnwindResume"

--- a/infer/tests/codetoanalyze/rust/sil/deref_multiple.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/deref_multiple.rs.ullbc.sil
@@ -12,20 +12,23 @@ define deref_multiple::main() : void {
       store &var_0 <- null:void
       store &x_1 <- 42:int
       store &ref_1_2 <- &x_1:.rust_mut = "const" .rust_pointer = "reference" *int
+      n0 = __rust_retag(&ref_1_2, &x_1, 0)
       store &ref_2_3 <- &ref_1_2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+      n1 = __rust_retag(&ref_2_3, &ref_1_2, 0)
       store &ref_3_4 <- &ref_2_3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
-      n0:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
-      n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n0
-      store &var_6 <- n1:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
-      n2:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
-      n3:.rust_mut = "const" .rust_pointer = "reference" *int = load n2
-      store &var_7 <- n3:.rust_mut = "const" .rust_pointer = "reference" *int
-      n4:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
-      n5:int = load n4
-      store &y_5 <- n5:int
+      n2 = __rust_retag(&ref_3_4, &ref_2_3, 0)
+      n3:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &ref_3_4
+      n4:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load n3
+      store &var_6 <- n4:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int
+      n5:.rust_mut = "const" .rust_pointer = "reference" *.rust_mut = "const" .rust_pointer = "reference" *int = load &var_6
+      n6:.rust_mut = "const" .rust_pointer = "reference" *int = load n5
+      store &var_7 <- n6:.rust_mut = "const" .rust_pointer = "reference" *int
+      n7:.rust_mut = "const" .rust_pointer = "reference" *int = load &var_7
+      n8:int = load n7
+      store &y_5 <- n8:int
       store &var_0 <- null:void
-      n6:void = load &var_0
-      ret n6
+      n9:void = load &var_0
+      ret n9
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/empty_struct.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/empty_struct.rs.ullbc.sil
@@ -13,9 +13,10 @@ define empty_struct::main() : void {
   #node_0:
       store &var_0 <- null:void
       store &var_3 <- &adder_1:.rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder
-      n0:.rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder = load &var_3
-      n1 = empty_struct::{empty_struct::Adder}::add(n0, 1, 2)
-      store &three_2 <- n1:int
+      n0 = __rust_retag(&var_3, &adder_1, 0)
+      n1:.rust_mut = "const" .rust_pointer = "reference" *empty_struct::Adder = load &var_3
+      n2 = empty_struct::{empty_struct::Adder}::add(n1, 1, 2)
+      store &three_2 <- n2:int
       jmp node_2
       .handlers node_1
       
@@ -24,8 +25,8 @@ define empty_struct::main() : void {
       
   #node_2:
       store &var_0 <- null:void
-      n2:void = load &var_0
-      ret n2
+      n3:void = load &var_0
+      ret n3
       
 }
 

--- a/infer/tests/codetoanalyze/rust/sil/mutate_through_reference.rs.ullbc.sil
+++ b/infer/tests/codetoanalyze/rust/sil/mutate_through_reference.rs.ullbc.sil
@@ -12,11 +12,12 @@ define mutate_through_reference::main() : void {
       store &var_0 <- null:void
       store &x_1 <- 10:int
       store &ptr_2 <- &x_1:.rust_mut = "mut" .rust_pointer = "reference" *int
-      n0:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
-      store n0 <- 20:int
+      n0 = __rust_retag(&ptr_2, &x_1, 1)
+      n1:.rust_mut = "mut" .rust_pointer = "reference" *int = load &ptr_2
+      store n1 <- 20:int
       store &var_0 <- null:void
-      n1:void = load &var_0
-      ret n1
+      n2:void = load &var_0
+      ret n2
       
 }
 


### PR DESCRIPTION
Adds a `__rust_retag` builtin for the Tree Borrows checker. It marks the places where a new borrow tag will be created.

The frontend emits `__rust_retag(to, from, is_mut)` after every reference creation (&x and &mut x). "to" is the place the reference is stored in, "from" is the borrowed expression, and is_mut says if the borrow is mutable. Raw pointer creations do not emit it, because raw pointers do not create tags.
