### PR TITLE
[rust][TreeBorrows] Create borrow tags

### DIFF
--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -142,6 +142,10 @@ let pp_ ~is_summary f
 
 let pp = pp_ ~is_summary:false
 
+let get_tree_borrows {tree_borrows} = tree_borrows
+
+let set_tree_borrows tree_borrows astate = {astate with tree_borrows}
+
 let set_path_condition path_condition astate = {astate with path_condition}
 
 let init_loop_header_info id ({path_condition; loop_header_info} as astate) =

--- a/infer/src/pulse/PulseAbductiveDomain.mli
+++ b/infer/src/pulse/PulseAbductiveDomain.mli
@@ -86,6 +86,10 @@ val leq : lhs:t -> rhs:t -> bool
 
 val pp : Format.formatter -> t -> unit
 
+val get_tree_borrows : t -> PulseTreeBorrows.state
+
+val set_tree_borrows : PulseTreeBorrows.state -> t -> t
+
 val mk_initial : Tenv.t -> ProcAttributes.t -> t
 
 val are_same_values_as_pre_formals :

--- a/infer/src/pulse/PulseModelsRust.ml
+++ b/infer/src/pulse/PulseModelsRust.ml
@@ -7,7 +7,20 @@
 
 open! IStd
 open PulseModelsImport
+module DSL = PulseModelsDSL
+
+let retag (dst_exp : Exp.t) (src_exp : Exp.t) (is_mut_exp : Exp.t) : model =
+  let open DSL.Syntax in
+  start_model
+  @@ fun () ->
+  if not (Config.is_checker_enabled TreeBorrows) then ret ()
+  else
+    let is_mut =
+      match is_mut_exp with Exp.Const (Const.Cint i) -> not (IntLit.iszero i) | _ -> false
+    in
+    exec_command (PulseTreeBorrowsOperations.exec_retag ~dst_exp ~src_exp ~is_mut)
+
 
 let matchers : matcher list =
   let open ProcnameDispatcher.Call in
-  [-"__rust_retag" &--> Basic.skip |> with_non_disj]
+  [-"__rust_retag" <>$ capt_exp $+ capt_exp $+ capt_exp $--> retag]

--- a/infer/src/pulse/PulseTreeBorrows.ml
+++ b/infer/src/pulse/PulseTreeBorrows.ml
@@ -7,9 +7,222 @@
 
 open! IStd
 module F = Format
+module AbstractValue = PulseAbstractValue
+module AVMap = AbstractValue.Map
+module AVSet = AbstractValue.Set
+module IdentMap = Stdlib.Map.Make (Ident)
 
-type state = unit [@@deriving compare, equal]
+module Tag = struct
+  type t = int [@@deriving compare, equal]
 
-let start () = ()
+  let pp fmt t = F.fprintf fmt "T%d" t
 
-let pp fmt () = F.pp_print_string fmt "()"
+  module Key = struct
+    type nonrec t = t [@@deriving compare]
+  end
+
+  module Map = Stdlib.Map.Make (Key)
+
+  module Info = struct
+    type t = {protector: bool; borrowed_cell: AbstractValue.t option} [@@deriving compare, equal]
+  end
+end
+
+module Perm = struct
+  type t = Reserved | Unique | Frozen | Disabled | ReservedConflicted [@@deriving compare, equal]
+
+  let pp fmt = function
+    | Reserved ->
+        F.pp_print_string fmt "Reserved"
+    | Unique ->
+        F.pp_print_string fmt "Unique"
+    | Frozen ->
+        F.pp_print_string fmt "Frozen"
+    | Disabled ->
+        F.pp_print_string fmt "Disabled"
+    | ReservedConflicted ->
+        F.pp_print_string fmt "ReservedConflicted"
+end
+
+module Operand = struct
+  (** how a value is designated in an instruction: through a temporary [root] identifier and/or an
+      access path of memory cells *)
+  type t = {root: Ident.t option; cells: AbstractValue.t list}
+
+  let untracked = {root= None; cells= []}
+
+  let of_place cell = {root= None; cells= [cell]}
+
+  let of_temp id cell = {root= Some id; cells= Option.to_list cell}
+
+  let extend op cell = {op with cells= op.cells @ [cell]}
+
+  let last_cell {cells; _} = List.last cells
+
+  let leaf {root; cells} = match root with None -> List.last cells | Some _ -> None
+end
+
+module St = struct
+  type t =
+    { tag_infos: Tag.Info.t Tag.Map.t
+    ; tags_at: Perm.t Tag.Map.t AVMap.t
+          (** for each memory cell, the permission each tag has on it *)
+    ; parent: Tag.t option Tag.Map.t  (** the borrow tree *)
+    ; pointer_tag: Tag.t AVMap.t  (** the tag currently held by each pointer cell *)
+    ; temps: Tag.t IdentMap.t  (** the tag carried by loaded temporaries *)
+    ; object_root: Tag.t AVMap.t  (** owner tag of each borrowed-from cell *)
+    ; next_tag: int }
+  [@@deriving compare, equal]
+
+  let empty =
+    { tag_infos= Tag.Map.empty
+    ; tags_at= AVMap.empty
+    ; parent= Tag.Map.empty
+    ; pointer_tag= AVMap.empty
+    ; temps= IdentMap.empty
+    ; object_root= AVMap.empty
+    ; next_tag= 0 }
+
+
+  let tag_fresh state ~protector ~borrowed_cell =
+    let t = state.next_tag in
+    let state =
+      { state with
+        tag_infos= Tag.Map.add t {Tag.Info.protector; borrowed_cell} state.tag_infos
+      ; next_tag= t + 1 }
+    in
+    (t, state)
+
+
+  let set_parent state tag p = {state with parent= Tag.Map.add tag p state.parent}
+
+  let entries_at state av = try AVMap.find av state.tags_at with Stdlib.Not_found -> Tag.Map.empty
+
+  let set_entry state av tag perm =
+    {state with tags_at= AVMap.add av (Tag.Map.add tag perm (entries_at state av)) state.tags_at}
+
+
+  let bind_pointer_tag state av tag = {state with pointer_tag= AVMap.add av tag state.pointer_tag}
+
+  let drop_pointer_tag state av =
+    if AVMap.mem av state.pointer_tag then
+      {state with pointer_tag= AVMap.remove av state.pointer_tag}
+    else state
+
+
+  let ensure_object_root state base_av =
+    match AVMap.find_opt base_av state.object_root with
+    | Some owner ->
+        (owner, state)
+    | None ->
+        let owner, state = tag_fresh state ~protector:false ~borrowed_cell:(Some base_av) in
+        let state = set_entry state base_av owner Perm.Unique in
+        let state = {state with object_root= AVMap.add base_av owner state.object_root} in
+        (owner, state)
+
+
+  let propagate_entries state ~parent_av ~child_av =
+    let pmap = entries_at state parent_av in
+    if Tag.Map.is_empty pmap then state
+    else
+      let cmap = entries_at state child_av in
+      let cmap' = Tag.Map.union (fun _ child_perm _parent_perm -> Some child_perm) cmap pmap in
+      {state with tags_at= AVMap.add child_av cmap' state.tags_at}
+
+
+  let propagate_along_path state (access_path : AbstractValue.t list) =
+    match access_path with
+    | [] | [_] ->
+        state
+    | first :: rest ->
+        List.fold rest ~init:(state, first) ~f:(fun (state, parent_av) child_av ->
+            (propagate_entries state ~parent_av ~child_av, child_av) )
+        |> fst
+
+
+  let sub_object_cells state ~succs av =
+    let rec go state visited order frontier =
+      match frontier with
+      | [] ->
+          (state, List.rev order)
+      | a :: rest ->
+          let children = succs a |> List.filter ~f:(fun c -> not (AVSet.mem c visited)) in
+          let state =
+            List.fold children ~init:state ~f:(fun st c ->
+                propagate_entries st ~parent_av:a ~child_av:c )
+          in
+          let visited = List.fold children ~init:visited ~f:(fun v c -> AVSet.add c v) in
+          go state visited (List.rev_append children order) (rest @ children)
+    in
+    go state (AVSet.singleton av) [av] [av]
+end
+
+type state = St.t [@@deriving compare, equal]
+
+let start () = St.empty
+
+let do_reborrow ~(protector : bool) (st : St.t) ~(succs : AbstractValue.t -> AbstractValue.t list)
+    ~(bind : AbstractValue.t option) ~(is_mut : bool) ~(src : Operand.t)
+    ~(borrowed_cell : AbstractValue.t) : St.t =
+  let st = St.propagate_along_path st src.Operand.cells in
+  let parent_opt =
+    match src with
+    | {Operand.root= Some id} ->
+        Option.map (IdentMap.find_opt id st.St.temps) ~f:(fun t -> (t, st))
+    | {Operand.root= None; cells= base :: _} ->
+        let owner, st = St.ensure_object_root st base in
+        Some (owner, st)
+    | _ ->
+        None
+  in
+  match parent_opt with
+  | None -> (
+    match bind with Some av -> St.drop_pointer_tag st av | None -> st )
+  | Some (parent_tag, st) -> (
+      let initial_perm = if is_mut then Perm.Reserved else Perm.Frozen in
+      let tag, st = St.tag_fresh st ~protector ~borrowed_cell:(Some borrowed_cell) in
+      let st = St.set_parent st tag (Some parent_tag) in
+      let st, sub_object = St.sub_object_cells st ~succs borrowed_cell in
+      let st = List.fold sub_object ~init:st ~f:(fun st a -> St.set_entry st a tag initial_perm) in
+      match bind with Some av -> St.bind_pointer_tag st av tag | None -> st )
+
+
+let exec_retag ~(dst : Operand.t) ~(src : Operand.t) ~(is_mut : bool) ~(protected : bool)
+    ~(succs : AbstractValue.t -> AbstractValue.t list) (st : state) : state =
+  match List.last src.Operand.cells with
+  | None ->
+      st
+  | Some borrowed_cell ->
+      do_reborrow ~protector:protected st ~succs ~bind:(Operand.leaf dst) ~is_mut ~src
+        ~borrowed_cell
+
+
+let tag_of_pointer av (st : state) = AVMap.find_opt av st.St.pointer_tag
+
+let parent_of tag (st : state) = Option.join (Tag.Map.find_opt tag st.St.parent)
+
+let perm_at ~cell tag (st : state) =
+  Option.bind (AVMap.find_opt cell st.St.tags_at) ~f:(Tag.Map.find_opt tag)
+
+
+let pp fmt (st : state) =
+  if Int.equal st.St.next_tag 0 then F.pp_print_string fmt "()"
+  else
+    let pp_parent fmt (tag, parent_opt) =
+      match parent_opt with
+      | Some parent_tag ->
+          F.fprintf fmt "%a<-%a" Tag.pp tag Tag.pp parent_tag
+      | None ->
+          Tag.pp fmt tag
+    in
+    let pp_cell fmt (av, perms) =
+      F.fprintf fmt "%a: {%a}" AbstractValue.pp av
+        (Pp.comma_seq (fun fmt (tag, perm) -> F.fprintf fmt "%a: %a" Tag.pp tag Perm.pp perm))
+        (Tag.Map.bindings perms)
+    in
+    let pp_ptr fmt (av, tag) = F.fprintf fmt "%a: %a" AbstractValue.pp av Tag.pp tag in
+    F.fprintf fmt "@[{tree= [%a];@ roots= [%a];@ cells= [%a];@ ptrs= [%a]}@]"
+      (Pp.comma_seq pp_parent) (Tag.Map.bindings st.St.parent) (Pp.comma_seq pp_ptr)
+      (AVMap.bindings st.St.object_root)
+      (Pp.comma_seq pp_cell) (AVMap.bindings st.St.tags_at) (Pp.comma_seq pp_ptr)
+      (AVMap.bindings st.St.pointer_tag)

--- a/infer/src/pulse/PulseTreeBorrows.mli
+++ b/infer/src/pulse/PulseTreeBorrows.mli
@@ -7,10 +7,55 @@
 
 open! IStd
 module F = Format
+module AbstractValue = PulseAbstractValue
 
 (** Abstract state of the Tree Borrows checker. *)
+
+module Tag : sig
+  type t [@@deriving compare, equal]
+
+  val pp : F.formatter -> t -> unit
+end
+
+module Perm : sig
+  type t = Reserved | Unique | Frozen | Disabled | ReservedConflicted [@@deriving compare, equal]
+
+  val pp : F.formatter -> t -> unit
+end
+
+module Operand : sig
+  (** how a value is designated in an instruction: through a temporary identifier and/or an access
+      path of memory cells *)
+  type t
+
+  val untracked : t
+
+  val of_place : AbstractValue.t -> t
+
+  val of_temp : Ident.t -> AbstractValue.t option -> t
+
+  val extend : t -> AbstractValue.t -> t
+
+  val last_cell : t -> AbstractValue.t option
+end
+
 type state [@@deriving compare, equal]
 
 val start : unit -> state
 
 val pp : F.formatter -> state -> unit
+
+val exec_retag :
+     dst:Operand.t
+  -> src:Operand.t
+  -> is_mut:bool
+  -> protected:bool
+  -> succs:(AbstractValue.t -> AbstractValue.t list)
+  -> state
+  -> state
+
+val tag_of_pointer : AbstractValue.t -> state -> Tag.t option
+
+val parent_of : Tag.t -> state -> Tag.t option
+
+val perm_at : cell:AbstractValue.t -> Tag.t -> state -> Perm.t option

--- a/infer/src/pulse/PulseTreeBorrowsOperations.ml
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.ml
@@ -6,8 +6,105 @@
  *)
 
 open! IStd
-module AbductiveDomain = PulseAbductiveDomain
+open PulseBasicInterface
+open PulseDomainInterface
+module Operand = PulseTreeBorrows.Operand
+
+let get_var_repr astate v = Formula.get_var_repr astate.AbductiveDomain.path_condition v
+
+let succs_of_heap ~get_var_repr heap av =
+  match UnsafeMemory.find_opt av heap with
+  | None ->
+      []
+  | Some edges ->
+      UnsafeMemory.Edges.fold edges ~init:[] ~f:(fun acc (access, (target, _hist)) ->
+          match (access : PulseAccess.t) with
+          | Dereference ->
+              acc
+          | FieldAccess _ | ArrayAccess _ ->
+              get_var_repr target :: acc )
+      |> List.dedup_and_sort ~compare:AbstractValue.compare
+
+
+let succs_of astate =
+  let get_var_repr = get_var_repr astate in
+  let post = (astate.AbductiveDomain.post :> BaseDomain.t) in
+  fun av -> succs_of_heap ~get_var_repr post.heap av
+
+
+let operand_of_exp astate exp : Operand.t =
+  let get_var_repr = get_var_repr astate in
+  let post = (astate.AbductiveDomain.post :> BaseDomain.t) in
+  let value_of_var v =
+    Option.map (UnsafeStack.find_opt v post.stack) ~f:(fun vo ->
+        get_var_repr (ValueOrigin.value vo) )
+  in
+  let field_cell parent fld =
+    Option.map (UnsafeMemory.find_edge_opt ~get_var_repr parent (FieldAccess fld) post.heap)
+      ~f:(fun (t, _) -> get_var_repr t )
+  in
+  let elem_cell arr idx_exp =
+    let index_matches iav (idx_exp : Exp.t) =
+      match idx_exp with
+      | Exp.Var id -> (
+        match value_of_var (Var.of_id id) with
+        | Some iv ->
+            AbstractValue.equal (get_var_repr iav) iv
+        | None ->
+            false )
+      | Exp.Const (Cint n) -> (
+        match Formula.as_constant_q astate.AbductiveDomain.path_condition iav with
+        | Some q ->
+            Q.equal q (Q.of_bigint (IntLit.to_big_int n))
+        | None ->
+            false )
+      | _ ->
+          false
+    in
+    Option.bind (UnsafeMemory.find_opt arr post.heap) ~f:(fun edges ->
+        UnsafeMemory.Edges.fold edges ~init:None ~f:(fun acc (access, (target, _hist)) ->
+            match acc with
+            | Some _ ->
+                acc
+            | None -> (
+              match (access : PulseAccess.t) with
+              | ArrayAccess (_, iav) when index_matches iav idx_exp ->
+                  Some (get_var_repr target)
+              | _ ->
+                  None ) ) )
+  in
+  let rec walk (e : Exp.t) : Operand.t option =
+    match e with
+    | Exp.Lvar pvar ->
+        Option.map (value_of_var (Var.of_pvar pvar)) ~f:Operand.of_place
+    | Exp.Var ident ->
+        Some (Operand.of_temp ident (value_of_var (Var.of_id ident)))
+    | Exp.Cast (_, e) ->
+        walk e
+    | Exp.Lfield ({exp= base}, fld, _) ->
+        Option.bind (walk base) ~f:(fun op ->
+            Option.map
+              (Option.bind (Operand.last_cell op) ~f:(fun p -> field_cell p fld))
+              ~f:(Operand.extend op) )
+    | Exp.Lindex (base, idx_exp) ->
+        Option.bind (walk base) ~f:(fun op ->
+            Option.map
+              (Option.bind (Operand.last_cell op) ~f:(fun a -> elem_cell a idx_exp))
+              ~f:(Operand.extend op) )
+    | _ ->
+        None
+  in
+  match walk exp with Some op -> op | None -> Operand.untracked
+
 
 let exec_load ~id:_ ~e:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate
 
 let exec_store ~lhs:_ ~rhs:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate
+
+let exec_retag ~dst_exp ~src_exp ~is_mut (astate : AbductiveDomain.t) =
+  let dst = operand_of_exp astate dst_exp in
+  let src = operand_of_exp astate src_exp in
+  AbductiveDomain.set_tree_borrows
+    (PulseTreeBorrows.exec_retag ~dst ~src ~is_mut ~protected:false ~succs:(succs_of astate)
+       (AbductiveDomain.get_tree_borrows astate) )
+    astate

--- a/infer/src/pulse/PulseTreeBorrowsOperations.mli
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.mli
@@ -6,10 +6,22 @@
  *)
 
 open! IStd
-module AbductiveDomain = PulseAbductiveDomain
 
 val exec_load :
-  id:Ident.t -> e:Exp.t -> typ:Typ.t -> loc:Location.t -> AbductiveDomain.t -> AbductiveDomain.t
+     id:Ident.t
+  -> e:Exp.t
+  -> typ:Typ.t
+  -> loc:Location.t
+  -> PulseAbductiveDomain.t
+  -> PulseAbductiveDomain.t
 
 val exec_store :
-  lhs:Exp.t -> rhs:Exp.t -> typ:Typ.t -> loc:Location.t -> AbductiveDomain.t -> AbductiveDomain.t
+     lhs:Exp.t
+  -> rhs:Exp.t
+  -> typ:Typ.t
+  -> loc:Location.t
+  -> PulseAbductiveDomain.t
+  -> PulseAbductiveDomain.t
+
+val exec_retag :
+  dst_exp:Exp.t -> src_exp:Exp.t -> is_mut:bool -> PulseAbductiveDomain.t -> PulseAbductiveDomain.t


### PR DESCRIPTION
Implements borrow tag creation for the Tree Borrows checker.

A tag is created by the `__rust_retag` model for every new reference. Tags form a tree: the first borrow of a memory cell creates an owner tag for it, and borrows of that cell are placed under the owner. A reborrow through a pointer is placed under the tag the pointer carries, and is skipped when we do not know that tag.

Each tag has a permission per memory cell (Pulse abstract value), which is how we model memory (`Reserved` for &mut, `Frozen` for &). The permissions of a new tag cover the whole borrowed object. Since Pulse materializes the heap lazily, the design is also lazy: when a cell appears later, it gets the permissions of its parent cell through propagation, at the moment a path or an object is walked again.

Nothing is reported yet. In future PRs we will add: canonicalize, so the state follows abstract values that Pulse proves equal; exec_store and exec_load, so tags are copied through stores and loads of pointers. Tests will come after these, because we need tag copying through stores and loads.