### PR TITLE
[rust][TreeBorrows] Track tags through loads and stores

### DIFF
--- a/infer/src/pulse/Pulse.ml
+++ b/infer/src/pulse/Pulse.ml
@@ -28,6 +28,16 @@ let report_topl_errors {InterproceduralAnalysis.proc_desc; err_log} summary =
   List.iter ~f summary
 
 
+let report_tree_borrows_errors {InterproceduralAnalysis.proc_desc; err_log} summary =
+  let f = function
+    | ContinueProgram astate ->
+        PulseTreeBorrowsOperations.report_errors proc_desc err_log astate
+    | _ ->
+        ()
+  in
+  List.iter ~f summary
+
+
 let is_hack_async tenv pname =
   match IRAttributes.load pname with
   | None ->
@@ -1982,6 +1992,8 @@ let analyze specialization ({InterproceduralAnalysis.tenv; proc_desc} as analysi
         if Config.pulse_transitive_access_enabled then
           PulseTransitiveAccessChecker.report_errors analysis_data summary ;
         report_topl_errors analysis_data summary.pre_post_list ;
+        if Config.is_checker_enabled TreeBorrows then
+          report_tree_borrows_errors analysis_data summary.pre_post_list ;
         if not (has_0_continue_program summary) then (
           (* Do not report unnecessary copy issue when no continue program, because it may have
              missed the statements that modify copied objects. *)

--- a/infer/src/pulse/PulseAbductiveDomain.ml
+++ b/infer/src/pulse/PulseAbductiveDomain.ml
@@ -2229,6 +2229,8 @@ module Summary = struct
 
   let get_topl {topl} = topl
 
+  let get_tree_borrows {tree_borrows} = tree_borrows
+
   let get_recursive_calls {recursive_calls} = recursive_calls
 
   let contains_unknown_values {unknown_values} = unknown_values

--- a/infer/src/pulse/PulseAbductiveDomain.mli
+++ b/infer/src/pulse/PulseAbductiveDomain.mli
@@ -506,6 +506,8 @@ module Summary : sig
 
   val get_topl : summary -> PulseTopl.state
 
+  val get_tree_borrows : summary -> PulseTreeBorrows.state
+
   val heap_paths_that_need_dynamic_type_specialization :
     summary -> AbstractValue.t Specialization.HeapPath.Map.t
 

--- a/infer/src/pulse/PulseModelsRust.ml
+++ b/infer/src/pulse/PulseModelsRust.ml
@@ -18,7 +18,8 @@ let retag (dst_exp : Exp.t) (src_exp : Exp.t) (is_mut_exp : Exp.t) : model =
     let is_mut =
       match is_mut_exp with Exp.Const (Const.Cint i) -> not (IntLit.iszero i) | _ -> false
     in
-    exec_command (PulseTreeBorrowsOperations.exec_retag ~dst_exp ~src_exp ~is_mut)
+    let* {location} = get_data in
+    exec_command (PulseTreeBorrowsOperations.exec_retag ~dst_exp ~src_exp ~is_mut ~loc:location)
 
 
 let matchers : matcher list =

--- a/infer/src/pulse/PulseTreeBorrows.ml
+++ b/infer/src/pulse/PulseTreeBorrows.ml
@@ -44,6 +44,10 @@ module Perm = struct
         F.pp_print_string fmt "ReservedConflicted"
 end
 
+module Access = struct
+  type t = Read | Write
+end
+
 module Operand = struct
   (** how a value is designated in an instruction: through a temporary [root] identifier and/or an
       access path of memory cells *)
@@ -110,6 +114,23 @@ module St = struct
     else state
 
 
+  let bind_temp state id tag = {state with temps= IdentMap.add id tag state.temps}
+
+  let drop_temp state id =
+    if IdentMap.mem id state.temps then {state with temps= IdentMap.remove id state.temps}
+    else state
+
+
+  (** The tag a value carries. For a loaded temporary it is its recorded tag, for a place it is the
+      tag held by its leaf cell *)
+  let tag_of_operand state (op : Operand.t) : Tag.t option =
+    match op.Operand.root with
+    | Some id ->
+        IdentMap.find_opt id state.temps
+    | None ->
+        Option.bind (Operand.last_cell op) ~f:(fun leaf -> AVMap.find_opt leaf state.pointer_tag)
+
+
   let ensure_object_root state base_av =
     match AVMap.find_opt base_av state.object_root with
     | Some owner ->
@@ -157,9 +178,11 @@ module St = struct
     go state (AVSet.singleton av) [av] [av]
 end
 
-type state = St.t [@@deriving compare, equal]
+type error = {loc: Location.t; description: string} [@@deriving compare, equal]
 
-let start () = St.empty
+type state = {st: St.t; errors: error list} [@@deriving compare, equal]
+
+let start () = {st= St.empty; errors= []}
 
 let do_reborrow ~(protector : bool) (st : St.t) ~(succs : AbstractValue.t -> AbstractValue.t list)
     ~(bind : AbstractValue.t option) ~(is_mut : bool) ~(src : Operand.t)
@@ -187,25 +210,83 @@ let do_reborrow ~(protector : bool) (st : St.t) ~(succs : AbstractValue.t -> Abs
       match bind with Some av -> St.bind_pointer_tag st av tag | None -> st )
 
 
+(* Fire a memory access through the pointer designated by [target]. This is where Tree Borrows
+   checks read/write permissions and detects undefined behavior. *)
+let exec_access ~(acc : Access.t) ~(target : Operand.t)
+    ~(succs : AbstractValue.t -> AbstractValue.t list) ~(loc : Location.t) (state : state) : state =
+  ignore (acc, target, succs, loc) ;
+  state
+
+
 let exec_retag ~(dst : Operand.t) ~(src : Operand.t) ~(is_mut : bool) ~(protected : bool)
-    ~(succs : AbstractValue.t -> AbstractValue.t list) (st : state) : state =
-  match List.last src.Operand.cells with
+    ~(succs : AbstractValue.t -> AbstractValue.t list) ~(loc : Location.t) (state : state) : state =
+  match Operand.last_cell src with
   | None ->
-      st
+      state
   | Some borrowed_cell ->
-      do_reborrow ~protector:protected st ~succs ~bind:(Operand.leaf dst) ~is_mut ~src
-        ~borrowed_cell
+      let st =
+        do_reborrow ~protector:protected state.st ~succs ~bind:(Operand.leaf dst) ~is_mut ~src
+          ~borrowed_cell
+      in
+      exec_access ~acc:Access.Read ~target:dst ~succs ~loc {state with st}
 
 
-let tag_of_pointer av (st : state) = AVMap.find_opt av st.St.pointer_tag
+let classify_typ (typ : Typ.t) = match typ.desc with Tptr (_, _) -> `Pointer | _ -> `Other
 
-let parent_of tag (st : state) = Option.join (Tag.Map.find_opt tag st.St.parent)
+let exec_load ~(id : Ident.t) ~(typ : Typ.t) ~(src : Operand.t)
+    ~(succs : AbstractValue.t -> AbstractValue.t list) ~(loc : Location.t) (state : state) : state =
+  match classify_typ typ with
+  | `Other ->
+      exec_access ~acc:Access.Read ~target:src ~succs ~loc state
+  | `Pointer ->
+      let st =
+        match
+          Option.bind (Operand.last_cell src) ~f:(fun av ->
+              AVMap.find_opt av state.st.St.pointer_tag )
+        with
+        | Some tag ->
+            St.bind_temp state.st id tag
+        | None ->
+            St.drop_temp state.st id
+      in
+      {state with st}
 
-let perm_at ~cell tag (st : state) =
-  Option.bind (AVMap.find_opt cell st.St.tags_at) ~f:(Tag.Map.find_opt tag)
+
+let exec_store ~(lhs : Operand.t) ~(rhs : Operand.t) ~(typ : Typ.t)
+    ~(succs : AbstractValue.t -> AbstractValue.t list) ~(loc : Location.t) (state : state) : state =
+  match classify_typ typ with
+  | `Other ->
+      exec_access ~acc:Access.Write ~target:lhs ~succs ~loc state
+  | `Pointer ->
+      let st =
+        match Operand.last_cell lhs with
+        | None ->
+            state.st
+        | Some cell -> (
+          match St.tag_of_operand state.st rhs with
+          | Some tag ->
+              St.bind_pointer_tag state.st cell tag
+          | None ->
+              St.drop_pointer_tag state.st cell )
+      in
+      {state with st}
 
 
-let pp fmt (st : state) =
+let report_errors proc_desc err_log (state : state) : unit =
+  List.iter (List.rev state.errors) ~f:(fun {loc; description} ->
+      Reporting.log_issue proc_desc err_log ~loc Checker.TreeBorrows IssueType.tree_borrows_ub
+        description )
+
+
+let tag_of_pointer av (state : state) = AVMap.find_opt av state.st.St.pointer_tag
+
+let parent_of tag (state : state) = Option.join (Tag.Map.find_opt tag state.st.St.parent)
+
+let perm_at ~cell tag (state : state) =
+  Option.bind (AVMap.find_opt cell state.st.St.tags_at) ~f:(Tag.Map.find_opt tag)
+
+
+let pp fmt ({st; errors= _} : state) =
   if Int.equal st.St.next_tag 0 then F.pp_print_string fmt "()"
   else
     let pp_parent fmt (tag, parent_opt) =

--- a/infer/src/pulse/PulseTreeBorrows.mli
+++ b/infer/src/pulse/PulseTreeBorrows.mli
@@ -51,8 +51,29 @@ val exec_retag :
   -> is_mut:bool
   -> protected:bool
   -> succs:(AbstractValue.t -> AbstractValue.t list)
+  -> loc:Location.t
   -> state
   -> state
+
+val exec_load :
+     id:Ident.t
+  -> typ:Typ.t
+  -> src:Operand.t
+  -> succs:(AbstractValue.t -> AbstractValue.t list)
+  -> loc:Location.t
+  -> state
+  -> state
+
+val exec_store :
+     lhs:Operand.t
+  -> rhs:Operand.t
+  -> typ:Typ.t
+  -> succs:(AbstractValue.t -> AbstractValue.t list)
+  -> loc:Location.t
+  -> state
+  -> state
+
+val report_errors : Procdesc.t -> Errlog.t -> state -> unit
 
 val tag_of_pointer : AbstractValue.t -> state -> Tag.t option
 

--- a/infer/src/pulse/PulseTreeBorrowsOperations.ml
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.ml
@@ -97,14 +97,32 @@ let operand_of_exp astate exp : Operand.t =
   match walk exp with Some op -> op | None -> Operand.untracked
 
 
-let exec_load ~id:_ ~e:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate
+let exec_load ~id ~e ~typ ~loc (astate : AbductiveDomain.t) =
+  let src = operand_of_exp astate e in
+  AbductiveDomain.set_tree_borrows
+    (PulseTreeBorrows.exec_load ~id ~typ ~src ~succs:(succs_of astate) ~loc
+       (AbductiveDomain.get_tree_borrows astate) )
+    astate
 
-let exec_store ~lhs:_ ~rhs:_ ~typ:_ ~loc:_ (astate : AbductiveDomain.t) = astate
 
-let exec_retag ~dst_exp ~src_exp ~is_mut (astate : AbductiveDomain.t) =
+let exec_store ~lhs ~rhs ~typ ~loc (astate : AbductiveDomain.t) =
+  let lhs = operand_of_exp astate lhs in
+  let rhs = operand_of_exp astate rhs in
+  AbductiveDomain.set_tree_borrows
+    (PulseTreeBorrows.exec_store ~lhs ~rhs ~typ ~succs:(succs_of astate) ~loc
+       (AbductiveDomain.get_tree_borrows astate) )
+    astate
+
+
+let report_errors proc_desc err_log summary =
+  PulseTreeBorrows.report_errors proc_desc err_log
+    (AbductiveDomain.Summary.get_tree_borrows summary)
+
+
+let exec_retag ~dst_exp ~src_exp ~is_mut ~loc (astate : AbductiveDomain.t) =
   let dst = operand_of_exp astate dst_exp in
   let src = operand_of_exp astate src_exp in
   AbductiveDomain.set_tree_borrows
-    (PulseTreeBorrows.exec_retag ~dst ~src ~is_mut ~protected:false ~succs:(succs_of astate)
+    (PulseTreeBorrows.exec_retag ~dst ~src ~is_mut ~protected:false ~succs:(succs_of astate) ~loc
        (AbductiveDomain.get_tree_borrows astate) )
     astate

--- a/infer/src/pulse/PulseTreeBorrowsOperations.mli
+++ b/infer/src/pulse/PulseTreeBorrowsOperations.mli
@@ -24,4 +24,11 @@ val exec_store :
   -> PulseAbductiveDomain.t
 
 val exec_retag :
-  dst_exp:Exp.t -> src_exp:Exp.t -> is_mut:bool -> PulseAbductiveDomain.t -> PulseAbductiveDomain.t
+     dst_exp:Exp.t
+  -> src_exp:Exp.t
+  -> is_mut:bool
+  -> loc:Location.t
+  -> PulseAbductiveDomain.t
+  -> PulseAbductiveDomain.t
+
+val report_errors : Procdesc.t -> Errlog.t -> PulseAbductiveDomain.Summary.summary -> unit


### PR DESCRIPTION
This PR does two things.

- Tags now follow pointers through memory. A load of a pointer records the tag the loaded pointer carries. A store of a pointer copies the tag it carries to the destination cell, or drops the destination's tag when the stored pointer is unknown.
- It adds the reporting pipeline. The state now also holds the list of detected violations, and report_errors reports `TREE_BORROWS_UB` issues.


Loads, stores and retags call `exec_access`, which is where reads and writes will be checked. For now exec_access does nothing, so no violation is ever recorded and nothing is reported. The next PR implements exec_access, and since reporting is already wired, the checker will then report real Tree Borrows errors. Tests will be added with the next PR.