### PR TITLE
[build] fix Java major version detection for JDK 20 and above

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,7 @@ _ACEOF
     rm -f conftest.java
     _USER_JAVA_HOME=$($JAVA -cp . conftest)
     if rm -f conftest.class; then
-       [javac_version_10_or_more=`echo "$JAVA_MAJOR_VERSION" | grep -q -e '^1[0-9]' && echo yes`]
+       [javac_version_10_or_more=`echo "$JAVA_MAJOR_VERSION" | grep -q -e '^[1-9][0-9]\+$' && echo yes`]
        if test "x$javac_version_10_or_more" = "xyes"; then
           USER_JAVA_HOME=$_USER_JAVA_HOME
        else


### PR DESCRIPTION
The check deciding whether to set `USER_JAVA_HOME` used the regexp `^1[0-9]`, which only matches Java major versions 10-19. It silently fails on 20, 21, 25, 26, etc.

Use `^[1-9][0-9]\+$` instead: it matches any version with two or more digits while still excluding single-digit ones (8, 9), so modern LTS JDKs are detected correctly.