### PR TITLE
[sarif] use a symbolic source-root uriBaseId for artifact locations

### DIFF
--- a/infer/src/base/Config.ml
+++ b/infer/src/base/Config.ml
@@ -190,6 +190,8 @@ let max_widens = 10000
 
 let kotlin_source_extension = ".kt"
 
+let sarif_source_root = "%srcroot%"
+
 (* Allow lists for C++ library functions *)
 
 let std_allow_listed_cpp_methods =

--- a/infer/src/base/Config.mli
+++ b/infer/src/base/Config.mli
@@ -92,6 +92,9 @@ val max_widens : int
 
 val os_type : os_type [@@warning "-unused-value-declaration"]
 
+val sarif_source_root : string
+(** URI base id used as the source root placeholder in SARIF reports *)
+
 val pp_version : Format.formatter -> unit -> unit
 
 val wrappers_dir : string

--- a/infer/src/integration/SarifReport.ml
+++ b/infer/src/integration/SarifReport.ml
@@ -69,9 +69,7 @@ let pp_results_header fmt =
 
 let loc_trace_to_sarifbug_record trace_list =
   let file_loc filename =
-    let absolute_source_name = Config.project_root ^/ filename in
-    let file_path = "file:" ^ filename in
-    {Sarifbug_j.uri= file_path; Sarifbug_j.uriBaseId= absolute_source_name}
+    {Sarifbug_j.uri= filename; Sarifbug_j.uriBaseId= Config.sarif_source_root}
   in
   let message description = {Sarifbug_j.text= description} in
   let region line_number column_number =
@@ -102,9 +100,7 @@ let pp_jsonbug fmt
   in
   let level = String.lowercase severity in
   let ruleId = bug_type in
-  let absolute_source_name = Config.project_root ^/ file in
-  let file_path = "file:" ^ file in
-  let file_loc = {Sarifbug_j.uri= file_path; uriBaseId= absolute_source_name} in
+  let file_loc = {Sarifbug_j.uri= file; uriBaseId= Config.sarif_source_root} in
   let region =
     match column with
     | -1 ->


### PR DESCRIPTION
The SARIF exporter built each `artifactLocation` with `uri` set to `"file:" ^ relative_path` and `uriBaseId` set to the absolute path `project_root ^/ relative_path`. This misuses the SARIF 2.1.0 fields: `uri` was a relative reference carrying a bogus `file:` scheme, and `uriBaseId` is meant to be a symbolic base-id name, not an absolute path. Emitting absolute paths there also leaks local filesystem layout into reports.

Set `uri` to the plain relative path and `uriBaseId` to the symbolic placeholder `"%srcroot%"` (new `Config.sarif_source_root`), following the convention from the SARIF spec (§3.4.4). Consumers resolve `%srcroot%` to the source tree root. This matches the SARIF output that has been running in production in the Lacework fork.