### PR TITLE
[java] fix crash when classes-out path contains regex metacharacters

### DIFF
--- a/infer/src/java/jClasspath.ml
+++ b/infer/src/java/jClasspath.ml
@@ -119,7 +119,10 @@ let load_from_verbose_output =
          4. [wrote path/to/File.java] leaves `path/to/File.java` in match group 6 (from java 11)*)
       "\\[wrote \
        \\(DirectoryFileObject\\[%s:\\(.*\\)\\|\\(\\(Regular\\|Simple\\)FileObject\\[\\(.*\\)\\)\\]\\|\\(.*\\)\\)\\]"
-      Config.javac_classes_out
+      (* the classes directory is a filesystem path (defaults to the project root), so it must be
+         quoted before being embedded in a regex, otherwise paths containing regex metacharacters
+         such as '+' (e.g. a project named [c++]) make [Str.regexp] raise [Parse_error] *)
+      (Str.quote Config.javac_classes_out)
     |> Str.regexp
   in
   let source_filename_re =


### PR DESCRIPTION
## Summary

Fixes #1941.

In `JClasspath.load_from_verbose_output`, the classes output directory `Config.javac_classes_out` (which defaults to the project root, i.e. the current working directory) is interpolated verbatim into a regex used to parse the output of `javac -verbose`:

```ocaml
Printf.sprintf "...DirectoryFileObject\\[%s:..." Config.javac_classes_out |> Str.regexp
```

Filesystem paths are not regexes. When the path contains a regex metacharacter, `Str.regexp` fails to compile the expression. The reported failure mode: checking a project out in a directory named `c++` (or any path containing `++`) makes `Re.Emacs.parse` raise `Parse_error`, which propagates as an uncaught internal error:

```
Uncaught Internal Error: (Re__Emacs.Parse_error)
...
Called from JavaFrontend__JClasspath.load_from_verbose_output in file "src/java/jClasspath.ml"
```

## Change

Quote the path with `Str.quote` before embedding it in the regex, so it matches the directory name literally. This is the pattern already used elsewhere in this codebase (`jTrans.ml`, `ProcnameDispatcher.ml`, `QualifiedCppName.ml`).

For normal paths without metacharacters the generated regex is unchanged.

## Verification

- Root cause confirmed against the real code on `main`: the interpolated path is a user-controlled filesystem path, and the crash site matches the backtrace in the issue exactly.
- Confirmed the fix is a no-op for plain paths and makes metacharacters literal via `Str.quote`.
- The only other regexes in this function do not interpolate paths; no other occurrence of a `Config.*` path embedded into a regex was found in `infer/src` (the one remaining case, `clang_libcxx_include_to_override_regex`, is by design a user-supplied regex).

## Test plan

`infer run -- make` inside a directory whose path contains `+` (e.g. `c++/`) no longer crashes during Java capture.