### PR TITLE
[java] Fix BufferOverrun FP on String.split with non-positive limit

### DIFF
--- a/infer/src/bufferoverrun/bufferOverrunModels.ml
+++ b/infer/src/bufferoverrun/bufferOverrunModels.ml
@@ -1638,13 +1638,20 @@ module JavaString = struct
     {exec; check= no_check}
 
 
-  let split_with_limit limit_exp =
+  (** [String.split(regex, limit)]. Non-positive [limit] behaves like [split]. Positive [limit] caps
+      the result length. Allocate from the receiver string; [limit] is not an array size. *)
+  let split_with_limit string_exp limit_exp =
     let exec ({integer_type_widths} as model_env) ~ret mem =
-      let dummy_exp = Exp.zero in
-      let length =
-        Sem.eval integer_type_widths dummy_exp mem |> range_itv_one_max_one_mone |> Dom.Val.of_itv
+      let from_string =
+        ArrObjCommon.eval_size model_env string_exp ~fn mem |> range_itv_one_max_one_mone
       in
-      malloc_and_set_length limit_exp model_env ~ret length mem
+      let limit_itv = Sem.eval integer_type_widths limit_exp mem |> Dom.Val.get_itv in
+      let length_itv =
+        if Boolean.is_true (Itv.gt_sem limit_itv Itv.zero) then
+          Itv.set_lb Itv.Bound.one (Itv.min_sem ~use_minmax_bound:true from_string limit_itv)
+        else from_string
+      in
+      malloc_and_set_length string_exp model_env ~ret (Dom.Val.of_itv length_itv) mem
     in
     {exec; check= no_check}
 
@@ -2349,7 +2356,7 @@ module Call = struct
         &:: "replace" <>$ capt_exp $+ any_arg_of_prim_typ int_typ $+ any_arg_of_prim_typ int_typ
         $--> JavaString.replace
       ; +PatternMatch.Java.implements_lang "String"
-        &:: "split" <>$ any_arg $+ any_arg $+ capt_exp $--> JavaString.split_with_limit
+        &:: "split" <>$ capt_exp $+ any_arg $+ capt_exp $--> JavaString.split_with_limit
       ; +PatternMatch.Java.implements_lang "String"
         &:: "split" <>$ capt_exp $+ any_arg $--> JavaString.split
       ; +PatternMatch.Java.implements_lang "String"

--- a/infer/tests/codetoanalyze/java/bufferoverrun/StringTest.java
+++ b/infer/tests/codetoanalyze/java/bufferoverrun/StringTest.java
@@ -36,4 +36,29 @@ class StringTest {
     String t = new String(s);
     char c = t.charAt(5);
   }
+
+  void split_with_negative_limit_Good() {
+    String s = "a,b";
+    String[] parts = s.split(",", -1);
+    int[] xs = new int[parts.length];
+  }
+
+  void split_with_zero_limit_Good() {
+    String s = "a,b";
+    String[] parts = s.split(",", 0);
+    int[] xs = new int[parts.length];
+  }
+
+  void split_with_positive_limit_Good() {
+    String s = "a,b";
+    String[] parts = s.split(",", 2);
+    int[] xs = new int[parts.length];
+  }
+
+  void split_no_limit_Good() {
+    String s = "a,b";
+    String[] parts = s.split(",");
+    int[] xs = new int[parts.length];
+  }
+
 }

--- a/infer/tests/codetoanalyze/java/performance/cost-issues.exp
+++ b/infer/tests/codetoanalyze/java/performance/cost-issues.exp
@@ -341,7 +341,7 @@ codetoanalyze/java/performance/StringTest.java, StringTest.last_index_of_linear(
 codetoanalyze/java/performance/StringTest.java, StringTest.last_index_of_linear_FN(java.lang.String):void, 23,  OnUIThread:false, []
 codetoanalyze/java/performance/StringTest.java, StringTest.replace_linear(java.lang.String):void, 7 + 5 ⋅ s.length + 3 ⋅ (s.length + 1),  OnUIThread:false, [{s.length + 1},Loop,{s.length},Loop]
 codetoanalyze/java/performance/StringTest.java, StringTest.split_linear(java.lang.String):void, 8 + 6 ⋅ (-1+max(2, s.length)),  OnUIThread:false, [{-1+max(2, s.length)},Loop]
-codetoanalyze/java/performance/StringTest.java, StringTest.split_with_limit_linear(java.lang.String,int):void, 9 + 6 ⋅ (max(1, limit)),  OnUIThread:false, [{max(1, limit)},Loop]
+codetoanalyze/java/performance/StringTest.java, StringTest.split_with_limit_linear(java.lang.String,int):void, 9 + 6 ⋅ (-1+max(2, s.length)),  OnUIThread:false, [{-1+max(2, s.length)},Loop]
 codetoanalyze/java/performance/StringTest.java, StringTest.startsWith_constant():java.lang.String, 17,  OnUIThread:false, []
 codetoanalyze/java/performance/StringTest.java, StringTest.string_constructor_constant():void, 44,  OnUIThread:false, []
 codetoanalyze/java/performance/StringTest.java, StringTest.string_constructor_linear(java.lang.String):void, 8 + 5 ⋅ s.length + 3 ⋅ (s.length + 1),  OnUIThread:false, [{s.length + 1},Loop,{s.length},Loop]


### PR DESCRIPTION
`String.split(regex, limit)` was modeled by treating `limit` as the malloc size of the result array. For `s.split(",", -1)` that produces `INFERBO_ALLOC_MAY_BE_NEGATIVE` with length `[-1, 1]`, even though the result length is never negative.

Size the result from the receiver (same idea as the one-arg overload). A positive `limit` is only used as an upper bound.

Fixes #1971