### PR TITLE
[clang] derive __config_site path from clang's target triple

### DIFF
--- a/facebook-clang-plugins/clang/setup.sh
+++ b/facebook-clang-plugins/clang/setup.sh
@@ -276,7 +276,10 @@ popd # build
 popd # $TMP
 
 # On Linux, copy __config_site to install directory. This way we don't need additional -I statements
-CONFIG_SITE="$CLANG_PREFIX/include/x86_64-unknown-linux-gnu/c++/v1/__config_site"
+# Ask the freshly built clang for its default target triple so this resolves on
+# any host architecture (x86_64, aarch64, ...) instead of hardcoding x86_64.
+CLANG_TARGET=$("$CLANG_PREFIX/bin/clang" -dumpmachine)
+CONFIG_SITE="$CLANG_PREFIX/include/$CLANG_TARGET/c++/v1/__config_site"
 if [[ "$PLATFORM" = "Linux" ]] && [[ -f "$CONFIG_SITE" ]]; then
     cp -f "$CONFIG_SITE" "$CLANG_PREFIX/include/c++/v1/__config_site"
 fi


### PR DESCRIPTION
## Problem

`facebook-clang-plugins/clang/setup.sh` copies libc++'s `__config_site` from a hardcoded path:

```sh
CONFIG_SITE="$CLANG_PREFIX/include/x86_64-unknown-linux-gnu/c++/v1/__config_site"
```

On any non-x86_64 Linux host the header is installed under a different triple directory (e.g. `include/aarch64-unknown-linux-gnu/c++/v1`), so the `-f "$CONFIG_SITE"` guard fails and the copy is silently skipped. Downstream compilations then miss the `__config_site` that the comment says we want to avoid extra `-I` flags for.

## Fix

Ask the clang we just built for its default target triple with `-dumpmachine` and build the path from that. This is a no-op on x86_64 Linux and makes the step work on aarch64 (and any other host).

## Test plan

Built the clang setup on both x86_64 and aarch64 Linux; `__config_site` is now copied to `$CLANG_PREFIX/include/c++/v1/` on both, whereas previously it was only copied on x86_64.