### PR TITLE
[build] drop to -O2 on aarch64 Linux (flambda -O3 breaks the assembler)

### DIFF
--- a/infer/src/Makefile
+++ b/infer/src/Makefile
@@ -224,6 +224,8 @@ sledge/llvm-config_ldflags.sexp: $(LLVM_OCAML_SENTINEL)
 endif
 
 
+BUILD_ARCH := $(shell uname -m)
+
 $(GENERATED_FROM_AUTOCONF): $(MAKEFILE_LIST)
 	TMPFILE=$$(mktemp $@.tmp.XXXX); \
 	INFER_GIT_COMMIT=$$(git --work-tree=$(ROOT_DIR) --git-dir=$(ROOT_DIR)/.git rev-parse --short HEAD || printf "unknown"); \
@@ -243,6 +245,7 @@ $(GENERATED_FROM_AUTOCONF): $(MAKEFILE_LIST)
 	  -e "s|@BUILD_JAVA_ANALYZERS[@]|$(BUILD_JAVA_ANALYZERS)|g" \
 	  -e "s|@BUILD_PYTHON_ANALYZERS[@]|$(BUILD_PYTHON_ANALYZERS)|g" \
 	  -e "s|@BUILD_PLATFORM[@]|$(BUILD_PLATFORM)|g" \
+	  -e "s|@BUILD_ARCH[@]|$(BUILD_ARCH)|g" \
 	  -e "s|@BUILD_RUST_ANALYZERS[@]|$(BUILD_RUST_ANALYZERS)|g" \
 	  -e "s|@BUILD_SWIFT_ANALYZERS[@]|$(BUILD_SWIFT_ANALYZERS)|g" \
 	  -e "s|@OPAMSWITCH[@]|$(OPAMSWITCH)|g" \

--- a/infer/src/dune.common.in
+++ b/infer/src/dune.common.in
@@ -33,6 +33,8 @@ let windows = is_yes "@WINDOWS_BUILD@"
 
 let darwin = String.equal "@BUILD_PLATFORM@" "Darwin"
 
+let arm64 = String.equal "@BUILD_ARCH@" "aarch64"
+
 let if_platform_env ?(else_ = "") s =
   match Sys.getenv_opt "PLATFORM_ENV" with Some pe when String.length pe > 0 -> s | _ -> else_
 

--- a/infer/src/dune.in
+++ b/infer/src/dune.in
@@ -39,8 +39,11 @@ let strict_flags =
 
 
 (* OCaml 5.2 on macos with -O3 can lead to compilation failing
-   https://github.com/ocaml/ocaml/issues/13596 *)
-let ocamlopt_flags_val = if darwin then "(:standard -O2)" else "(:standard -O3)"
+   https://github.com/ocaml/ocaml/issues/13596
+   On aarch64 Linux, -O3 inlines so aggressively into infer.ml that a conditional
+   branch in the resulting object exceeds the assembler's +/-1MB range
+   ("conditional branch out of range"), so use -O2 there too. *)
+let ocamlopt_flags_val = if darwin || arm64 then "(:standard -O2)" else "(:standard -O3)"
 
 let env_stanza =
   Format.sprintf


### PR DESCRIPTION
## Problem

Building infer on aarch64 Linux with the default flambda `-O3` fails: the optimizer inlines so aggressively into `infer.ml` that a conditional branch in the generated object exceeds the AArch64 assembler's ±1MB branch displacement, and the build dies with `conditional branch out of range`.

macOS already special-cases `-O2` for an unrelated flambda issue (ocaml/ocaml#13596), so this extends the same treatment to aarch64.

## Changes

- `infer/src/Makefile`: thread `uname -m` through the autoconf-style substitution as `BUILD_ARCH`, mirroring the existing `BUILD_PLATFORM` handling.
- `infer/src/dune.common.in`: expose `arm64`.
- `infer/src/dune.in`: use `-O2` when `darwin || arm64`, `-O3` otherwise.

No change to x86_64 Linux builds.

## Test plan

Built infer from source on aarch64 Linux: fails on `main` with `conditional branch out of range`, succeeds with this change. x86_64 Linux and macOS builds are unaffected (`-O3` and `-O2` respectively, same as before).