### PR TITLE
[ci] fix stale-bot never closing issues (stuck _state cache)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,13 +24,22 @@ on:
 permissions:
   issues: write
   pull-requests: read
+  # actions/stale is stateful: when a run hits operations-per-run it records
+  # the issues it already handled in an Actions cache entry named `_state`, and
+  # deletes that entry once it has worked through the whole backlog. Deleting a
+  # cache entry requires `actions: write`. Without it the delete fails with
+  # "Error delete _state: [403] Resource not accessible by integration", the
+  # entry never expires, and every subsequent run skips the same issues
+  # ("issue skipped due being processed during the previous run") -- so they
+  # are marked stale but can never progress to being closed.
+  actions: write
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/infer'
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # ~18 months of inactivity before an issue is marked stale.
           days-before-issue-stale: 540


### PR DESCRIPTION
## Problem

The stale workflow has been marking issues stale since it landed, but has not closed a single issue since 2026-08-08. ~104 issues are currently sitting open with a `stale` label, many labeled back on 2026-07-07 — long past the 30-day close window.

## Cause

`actions/stale` is stateful. When a run hits `operations-per-run` it records the issues it already processed in an Actions cache entry named `_state`, then deletes that entry once it has worked through the whole backlog so the next run starts a fresh cycle.

Deleting a cache entry requires the `actions: write` permission, which the workflow never granted. Every run ends with:

```
##[warning]Error delete _state: [403] Resource not accessible by integration
```

So the entry (created 2026-07-29) became permanent, and every run since logs:

```
[#1276] issue skipped due being processed during the previous run
```

for the same 168 issues. They get marked stale but can never advance to the close step. Note the job still reports `success`, which is why this went unnoticed.

## Fix

- Grant `actions: write` so the action can clear its own state.
- Bump `actions/stale` v9 → v10, moving off the deprecated Node 20 runtime (also emitted as a warning on every run). GitHub-hosted runners are well past the v2.327.1 minimum v10 requires.

## Required manual step

The existing poisoned cache entry must be deleted once by hand, otherwise the first run after this merges still skips the stuck issues:

```sh
gh cache delete _state -R facebook/infer
```

## Test plan

Inspected the run logs for the skip messages and the 403 warning, and confirmed via the API that cache key `_state` on `refs/heads/main` was created 2026-07-29 and has been re-read but never deleted on every run since.

The workflow is gated on `if: github.repository == 'facebook/infer'`, so it cannot be exercised end-to-end from a fork.

Expect a burst of closures on the first run after the cache is cleared — capped by `operations-per-run: 200`, so the ~104 stuck issues will drain over a day or two.